### PR TITLE
Ascii test the Classical Variation of the French Defense

### DIFF
--- a/tests/unit/AsciiTest.php
+++ b/tests/unit/AsciiTest.php
@@ -12,6 +12,8 @@ use Chess\Tests\Sample\Opening\Benoni\BenkoGambit;
 use Chess\Tests\Sample\Opening\RuyLopez\Exchange as RuyLopezExchange;
 use Chess\Tests\Sample\Opening\Sicilian\Closed as ClosedSicilian;
 use Chess\Tests\Sample\Opening\Benoni\FianchettoVariation as BenoniFianchettoVariation;
+use Chess\Tests\Sample\Opening\FrenchDefense\Classical as FrenchDefenseClassical;
+
 
 class AsciiTest extends AbstractUnitTestCase
 {
@@ -186,6 +188,51 @@ class AsciiTest extends AbstractUnitTestCase
         ];
 
         $board = (new Ascii())->toBoard($expected, Symbol::BLACK, $castling);
+        $array = (new Ascii())->toArray($board);
+
+        $this->assertEquals($expected, $array);
+    }
+
+    /**
+     * @test
+     */
+    public function french_defense_classical_to_array()
+    {
+        $board = (new FrenchDefenseClassical(new Board()))->play();
+
+        $array = (new Ascii())->toArray($board);
+
+        $expected = [
+            7 => [ ' r ', ' n ', ' b ', ' q ', ' k ', ' b ', ' . ', ' r ' ],
+            6 => [ ' p ', ' p ', ' p ', ' . ', ' . ', ' p ', ' p ', ' p ' ],
+            5 => [ ' . ', ' . ', ' . ', ' . ', ' p ', ' n ', ' . ', ' . ' ],
+            4 => [ ' . ', ' . ', ' . ', ' p ', ' . ', ' . ', ' . ', ' . ' ],
+            3 => [ ' . ', ' . ', ' . ', ' P ', ' P ', ' . ', ' . ', ' . ' ],
+            2 => [ ' . ', ' . ', ' N ', ' . ', ' . ', ' . ', ' . ', ' . ' ],
+            1 => [ ' P ', ' P ', ' P ', ' . ', ' . ', ' P ', ' P ', ' P ' ],
+            0 => [ ' R ', ' . ', ' B ', ' Q ', ' K ', ' B ', ' N ', ' R ' ],
+        ];
+
+        $this->assertEquals($expected, $array);
+    }
+
+    /**
+     * @test
+     */
+    public function french_defense_classical_to_board()
+    {
+        $expected = [
+            7 => [ ' r ', ' n ', ' b ', ' q ', ' k ', ' b ', ' . ', ' r ' ],
+            6 => [ ' p ', ' p ', ' p ', ' . ', ' . ', ' p ', ' p ', ' p ' ],
+            5 => [ ' . ', ' . ', ' . ', ' . ', ' p ', ' n ', ' . ', ' . ' ],
+            4 => [ ' . ', ' . ', ' . ', ' p ', ' . ', ' . ', ' . ', ' . ' ],
+            3 => [ ' . ', ' . ', ' . ', ' P ', ' P ', ' . ', ' . ', ' . ' ],
+            2 => [ ' . ', ' . ', ' N ', ' . ', ' . ', ' . ', ' . ', ' . ' ],
+            1 => [ ' P ', ' P ', ' P ', ' . ', ' . ', ' P ', ' P ', ' P ' ],
+            0 => [ ' R ', ' . ', ' B ', ' Q ', ' K ', ' B ', ' N ', ' R ' ],
+        ];
+
+        $board = (new Ascii())->toBoard($expected, Symbol::WHITE);
         $array = (new Ascii())->toArray($board);
 
         $this->assertEquals($expected, $array);


### PR DESCRIPTION
Fixes #76 
Created `french_defense_classical_to_array()` function to test sample chess opening in AsciiTest.
Created `french_defense_classical_to_board()` function to be able to print the ascii representation of the resulting board.

Please let me know if anything needs to be improved. 
Thank you!