### PR TITLE
Issue/130 add the backward pawn evaluation to the chess heuristic picture

### DIFF
--- a/src/HeuristicPicture.php
+++ b/src/HeuristicPicture.php
@@ -2,10 +2,11 @@
 
 namespace Chess;
 
-use Chess\Evaluation\IsolatedPawnEvaluation;
 use Chess\Evaluation\AttackEvaluation;
+use Chess\Evaluation\BackwardPawnEvaluation;
 use Chess\Evaluation\CenterEvaluation;
 use Chess\Evaluation\ConnectivityEvaluation;
+use Chess\Evaluation\IsolatedPawnEvaluation;
 use Chess\Evaluation\KingSafetyEvaluation;
 use Chess\Evaluation\MaterialEvaluation;
 use Chess\Evaluation\PressureEvaluation;
@@ -21,16 +22,17 @@ class HeuristicPicture extends Player
 {
     protected $dimensions = [
         MaterialEvaluation::class => 21,
-        CenterEvaluation::class => 13,
-        ConnectivityEvaluation::class => 8,
-        SpaceEvaluation::class => 8,
-        PressureEvaluation::class => 8,
-        KingSafetyEvaluation::class => 8,
-        TacticsEvaluation::class => 8,
-        AttackEvaluation::class => 8,
-        DoubledPawnEvaluation::class => 8,
+        CenterEvaluation::class => 21,
+        ConnectivityEvaluation::class => 13,
+        SpaceEvaluation::class => 5,
+        PressureEvaluation::class => 5,
+        KingSafetyEvaluation::class => 5,
+        TacticsEvaluation::class => 5,
+        AttackEvaluation::class => 5,
+        DoubledPawnEvaluation::class => 5,
         PassedPawnEvaluation::class => 5,
         IsolatedPawnEvaluation::class => 5,
+        BackwardPawnEvaluation::class => 5,
     ];
 
     protected $picture = [];

--- a/tests/unit/Game/HeuristicPictureTest.php
+++ b/tests/unit/Game/HeuristicPictureTest.php
@@ -19,10 +19,10 @@ class HeuristicPictureTest extends AbstractUnitTestCase
 
         $expected = [
             Symbol::WHITE => [
-                [ 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0 ],
+                [ 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0 ],
             ],
             Symbol::BLACK => [
-                [ 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0 ],
+                [ 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0 ],
             ],
         ];
 
@@ -41,7 +41,7 @@ class HeuristicPictureTest extends AbstractUnitTestCase
         $game->playFen('rnbqkbnr/pppp1ppp/8/4p3/4P3/8/PPPP1PPP/RNBQKBNR w');
 
         $expected = [
-            [ 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0 ],
+            [ 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0 ],
         ];
 
         $balance = $game->heuristicPicture(true);
@@ -60,7 +60,7 @@ class HeuristicPictureTest extends AbstractUnitTestCase
         $game->play('b', 'gxf6');
 
         $expected = [
-            [ -1, -1, -1, 1, 1, 0, 0, 0, 1, -1, -1 ],
+            [ -1, -1, -1, 1, 1, 0, 0, 0, 1, -1, -1, 0 ],
         ];
 
         $balance = $game->heuristicPicture(true);
@@ -77,7 +77,7 @@ class HeuristicPictureTest extends AbstractUnitTestCase
         $game->loadFen('r1bqkbnr/pppp2pp/2n5/4pp2/4PP2/2N5/PPPP2PP/R1BQKBNR w KQkq - 2 4');
 
         $expected = [
-            [ 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0 ],
+            [ 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0 ],
         ];
 
         $balance = $game->heuristicPicture(true);

--- a/tests/unit/HeuristicPictureTest.php
+++ b/tests/unit/HeuristicPictureTest.php
@@ -40,10 +40,10 @@ class HeuristicPictureTest extends AbstractUnitTestCase
 
         $expected = [
             Symbol::WHITE => [
-                [ 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0 ],
+                [ 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0 ],
             ],
             Symbol::BLACK => [
-                [ 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0 ],
+                [ 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0 ],
             ],
         ];
 
@@ -62,8 +62,8 @@ class HeuristicPictureTest extends AbstractUnitTestCase
             ->end();
 
         $expected = [
-            Symbol::WHITE => [ 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0 ],
-            Symbol::BLACK => [ 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0 ],
+            Symbol::WHITE => [ 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0 ],
+            Symbol::BLACK => [ 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0 ],
         ];
 
         $this->assertEquals($expected, $end);
@@ -81,7 +81,7 @@ class HeuristicPictureTest extends AbstractUnitTestCase
             ->getBalance();
 
         $expected = [
-            [ 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0 ],
+            [ 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0 ],
         ];
 
         $this->assertEquals($expected, $balance);
@@ -100,10 +100,10 @@ class HeuristicPictureTest extends AbstractUnitTestCase
 
         $expected = [
             Symbol::WHITE => [
-                [ 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0 ],
+                [ 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0 ],
             ],
             Symbol::BLACK => [
-                [ 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0 ],
+                [ 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0 ],
             ],
         ];
 
@@ -122,8 +122,8 @@ class HeuristicPictureTest extends AbstractUnitTestCase
             ->end();
 
         $expected = [
-            Symbol::WHITE => [ 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0 ],
-            Symbol::BLACK => [ 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0 ],
+            Symbol::WHITE => [ 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0 ],
+            Symbol::BLACK => [ 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0 ],
         ];
 
         $this->assertEquals($expected, $end);
@@ -141,7 +141,7 @@ class HeuristicPictureTest extends AbstractUnitTestCase
             ->getBalance();
 
         $expected = [
-            [ 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0 ],
+            [ 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0 ],
         ];
 
         $this->assertEquals($expected, $balance);
@@ -159,8 +159,8 @@ class HeuristicPictureTest extends AbstractUnitTestCase
             ->end();
 
         $expected = [
-            Symbol::WHITE => [ 0, 0, 0.9, 0.2, 0, 0, 0, 0, 0, 0, 0 ],
-            Symbol::BLACK => [ 0, 1, 0, 1, 1, 1, 0, 0, 0, 0, 0 ],
+            Symbol::WHITE => [ 0, 0, 0.9, 0.2, 0, 0, 0, 0, 0, 0, 0, 0 ],
+            Symbol::BLACK => [ 0, 1, 0, 1, 1, 1, 0, 0, 0, 0, 0, 0 ],
         ];
 
         $this->assertEquals($expected, $end);
@@ -178,8 +178,8 @@ class HeuristicPictureTest extends AbstractUnitTestCase
             ->getBalance();
 
         $expected = [
-            [ 0, -1, 0.6, -0.6, 0, 0, 0, 0, 0, 0, 0 ],
-            [ 0, -1, 0.9, -0.8, -1, -1, 0, 0, 0, 0, 0 ],
+            [ 0, -1, 0.6, -0.6, 0, 0, 0, 0, 0, 0, 0, 0 ],
+            [ 0, -1, 0.9, -0.8, -1, -1, 0, 0, 0, 0, 0, 0 ],
         ];
 
         $this->assertEquals($expected, $balance);
@@ -197,8 +197,8 @@ class HeuristicPictureTest extends AbstractUnitTestCase
             ->end();
 
         $expected = [
-            Symbol::WHITE => [ 1, 0, 0.07, 0.8, 1, 1, 0, 0, 0, 0, 0 ],
-            Symbol::BLACK => [ 0, 1, 0.93, 0.4, 0.4, 0, 0.5, 0.1, 0, 0, 0 ],
+            Symbol::WHITE => [ 1, 0, 0.07, 0.8, 1, 1, 0, 0, 0, 0, 0, 0 ],
+            Symbol::BLACK => [ 0, 1, 0.93, 0.4, 0.4, 0, 0.5, 0.1, 0, 0, 0, 0 ],
         ];
 
         $this->assertEquals($expected, $end);
@@ -216,10 +216,10 @@ class HeuristicPictureTest extends AbstractUnitTestCase
             ->getBalance();
 
         $expected = [
-            [ 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0 ],
-            [ 0, 0, -0.35, 0, 0.2, 0.25, 0, 0, 0, 0, 0 ],
-            [ 0, -1, -1, 0.8, 0.4, 0.25, 0, -0.8, 0, 0, 0 ],
-            [ 1, -1, -0.86, 0.4, 0.6, 1, -0.5, -0.1, 0, 0, 0 ],
+            [ 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0 ],
+            [ 0, 0, -0.35, 0, 0.2, 0.25, 0, 0, 0, 0, 0, 0 ],
+            [ 0, -1, -1, 0.8, 0.4, 0.25, 0, -0.8, 0, 0, 0, 0 ],
+            [ 1, -1, -0.86, 0.4, 0.6, 1, -0.5, -0.1, 0, 0, 0, 0 ],
         ];
 
         $this->assertEquals($expected, $balance);
@@ -237,8 +237,8 @@ class HeuristicPictureTest extends AbstractUnitTestCase
         $evaluation = $heuristicPicture->evaluate();
 
         $expected = [
-            Symbol::WHITE => 39.99,
-            Symbol::BLACK => 22.4,
+            Symbol::WHITE => 48.24,
+            Symbol::BLACK => 17.04,
         ];
 
         $this->assertEquals($expected, $evaluation);
@@ -256,7 +256,7 @@ class HeuristicPictureTest extends AbstractUnitTestCase
             ->getBalance();
 
         $expected = [
-            [ 0, 1, -1, 1, 0, 0, 0, 0, 0, 0, 0 ],
+            [ 0, 1, -1, 1, 0, 0, 0, 0, 0, 0, 0, 0 ],
         ];
 
         $this->assertEquals($expected, $balance);
@@ -274,8 +274,8 @@ class HeuristicPictureTest extends AbstractUnitTestCase
             ->getBalance();
 
         $expected = [
-            [ 0, 0.5, -0.4, 0.17, 0, 0, 0, 0, 0, 0, 0 ],
-            [ 0, 1, -0.6, 0.83, 0, 0, -1, -1, 0, 0, 0 ],
+            [ 0, 0.5, -0.4, 0.17, 0, 0, 0, 0, 0, 0, 0, 0 ],
+            [ 0, 1, -0.6, 0.83, 0, 0, -1, -1, 0, 0, 0, -1 ],
         ];
 
         $this->assertEquals($expected, $balance);
@@ -293,9 +293,9 @@ class HeuristicPictureTest extends AbstractUnitTestCase
             ->getBalance();
 
         $expected = [
-            [ 0, 0.5, -0.25, 0.17, 0, 0, 0, 0, 0, 0, 0 ],
-            [ 0, 1, -0.38, 0.83, 0, 0, -0.5, -0.5, 0, 0, 0 ],
-            [ 0, 1, -0.5, 0.33, -0.5, 0, -1, -1, 0, 0, 0 ],
+            [ 0, 0.5, -0.25, 0.17, 0, 0, 0, 0, 0, 0, 0, 0 ],
+            [ 0, 1, -0.38, 0.83, 0, 0, -0.5, -0.5, 0, 0, 0, -1 ],
+            [ 0, 1, -0.5, 0.33, -0.5, 0, -1, -1, 0, 0, 0, -1 ],
         ];
 
         $this->assertEquals($expected, $balance);
@@ -313,10 +313,10 @@ class HeuristicPictureTest extends AbstractUnitTestCase
             ->getBalance();
 
         $expected = [
-            [ 0, 0.5, -0.25, 0.17, 0, 0, 0, 0, 0, 0, 0 ],
-            [ 0, 1, -0.38, 0.83, 0, 0, -0.5, -0.5, 0, 0, 0 ],
-            [ 0, 1, -0.5, 0.33, -0.5, 0, -1, -1, 0, 0, 0 ],
-            [ 0, 0.5, -0.38, 0.34, -0.5, 0, 0, 0, 0, 0, 0 ],
+            [ 0, 0.5, -0.25, 0.17, 0, 0, 0, 0, 0, 0, 0, 0 ],
+            [ 0, 1, -0.38, 0.83, 0, 0, -0.5, -0.5, 0, 0, 0, -1 ],
+            [ 0, 1, -0.5, 0.33, -0.5, 0, -1, -1, 0, 0, 0, -1 ],
+            [ 0, 0.5, -0.38, 0.34, -0.5, 0, 0, 0, 0, 0, 0, 0 ],
         ];
 
         $this->assertEquals($expected, $balance);
@@ -335,10 +335,10 @@ class HeuristicPictureTest extends AbstractUnitTestCase
 
         $expected = [
             Symbol::WHITE => [
-                [ 0, 1, 0, 1, 0, 0, 0, 0, 0, 0, 0 ],
+                [ 0, 1, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0 ],
             ],
             Symbol::BLACK => [
-                [ 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0 ],
+                [ 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0 ],
             ],
         ];
 
@@ -358,12 +358,12 @@ class HeuristicPictureTest extends AbstractUnitTestCase
 
         $expected = [
             Symbol::WHITE => [
-                [ 0, 0.5, 0.6, 0.17, 0, 0, 0, 0, 0, 0, 0 ],
-                [ 0, 1, 0, 1, 1, 0, 0, 0, 0, 0, 0 ],
+                [ 0, 0.5, 0.6, 0.17, 0, 0, 0, 0, 0, 0, 0, 0 ],
+                [ 0, 1, 0, 1, 1, 0, 0, 0, 0, 0, 0, 0 ],
             ],
             Symbol::BLACK => [
-                [ 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0 ],
-                [ 0, 0, 0.6, 0.17, 1, 0, 1, 1, 0, 0, 0 ],
+                [ 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0 ],
+                [ 0, 0, 0.6, 0.17, 1, 0, 1, 1, 0, 0, 0, 1 ],
             ],
         ];
 
@@ -383,14 +383,14 @@ class HeuristicPictureTest extends AbstractUnitTestCase
 
         $expected = [
             Symbol::WHITE => [
-                [ 0, 0.5, 0.38, 0.17, 0, 0, 0, 0, 0, 0, 0 ],
-                [ 0, 1, 0, 1, 0.5, 0, 0, 0, 0, 0, 0 ],
-                [ 0, 1, 0.5, 0.5, 0.5, 0, 0, 0, 0, 0, 0 ],
+                [ 0, 0.5, 0.38, 0.17, 0, 0, 0, 0, 0, 0, 0, 0 ],
+                [ 0, 1, 0, 1, 0.5, 0, 0, 0, 0, 0, 0, 0 ],
+                [ 0, 1, 0.5, 0.5, 0.5, 0, 0, 0, 0, 0, 0, 0 ],
             ],
             Symbol::BLACK => [
-                [ 0, 0, 0.63, 0, 0, 0, 0, 0, 0, 0, 0 ],
-                [ 0, 0, 0.38, 0.17, 0.5, 0, 0.5, 0.5, 0, 0, 0 ],
-                [ 0, 0, 1, 0.17, 1, 0, 1, 1, 0, 0, 0 ],
+                [ 0, 0, 0.63, 0, 0, 0, 0, 0, 0, 0, 0, 0 ],
+                [ 0, 0, 0.38, 0.17, 0.5, 0, 0.5, 0.5, 0, 0, 0, 1 ],
+                [ 0, 0, 1, 0.17, 1, 0, 1, 1, 0, 0, 0, 1 ],
             ],
         ];
 
@@ -409,7 +409,7 @@ class HeuristicPictureTest extends AbstractUnitTestCase
             ->getBalance();
 
         $expected = [
-            [ 0, 1, -1, 1, -1, 0, -1, -1, 0, 0, 0 ],
+            [ 0, 1, -1, 1, -1, 0, -1, -1, 0, 0, 0, 0 ],
         ];
 
         $this->assertEquals($expected, $balance);

--- a/tests/unit/ML/Supervised/Classification/LinearCombinationLabellerTest.php
+++ b/tests/unit/ML/Supervised/Classification/LinearCombinationLabellerTest.php
@@ -24,7 +24,7 @@ class LinearCombinationLabellerTest extends AbstractUnitTestCase
 
         self::$permutations = (new RestrictedPermutationWithRepetition())
             ->get(
-                [5, 8, 13, 21, 34],
+                [ 5, 8, 13, 21 ],
                 count($dimensions),
                 100
             );
@@ -94,8 +94,8 @@ class LinearCombinationLabellerTest extends AbstractUnitTestCase
         $end = end($balance);
 
         $expected = [
-            Symbol::WHITE => 16,
-            Symbol::BLACK => 6,
+            Symbol::WHITE => 31,
+            Symbol::BLACK => 54,
         ];
 
         $label = (new LinearCombinationLabeller(self::$permutations))->label($end);
@@ -119,8 +119,8 @@ class LinearCombinationLabellerTest extends AbstractUnitTestCase
         $end = end($balance);
 
         $expected = [
-            Symbol::WHITE => 18,
-            Symbol::BLACK => 6,
+            Symbol::WHITE => 9,
+            Symbol::BLACK => 1,
         ];
 
         $label = (new LinearCombinationLabeller(self::$permutations))->label($end);
@@ -142,8 +142,8 @@ class LinearCombinationLabellerTest extends AbstractUnitTestCase
         $end = end($balance);
 
         $expected = [
-            Symbol::WHITE => 6,
-            Symbol::BLACK => 37,
+            Symbol::WHITE => 129,
+            Symbol::BLACK => 88,
         ];
 
         $label = (new LinearCombinationLabeller(self::$permutations))->label($end);
@@ -165,8 +165,8 @@ class LinearCombinationLabellerTest extends AbstractUnitTestCase
         $end = end($balance);
 
         $expected = [
-            Symbol::WHITE => 70,
-            Symbol::BLACK => 5,
+            Symbol::WHITE => 112,
+            Symbol::BLACK => 131,
         ];
 
         $label = (new LinearCombinationLabeller(self::$permutations))->label($end);
@@ -188,8 +188,8 @@ class LinearCombinationLabellerTest extends AbstractUnitTestCase
         $end = end($balance);
 
         $expected = [
-            Symbol::WHITE => 1165,
-            Symbol::BLACK => 45,
+            Symbol::WHITE => 7229,
+            Symbol::BLACK => 91,
         ];
 
         $label = (new LinearCombinationLabeller(self::$permutations))->label($end);
@@ -211,8 +211,8 @@ class LinearCombinationLabellerTest extends AbstractUnitTestCase
         $end = end($balance);
 
         $expected = [
-            Symbol::WHITE => 16,
-            Symbol::BLACK => 45,
+            Symbol::WHITE => 10,
+            Symbol::BLACK => 40,
         ];
 
         $label = (new LinearCombinationLabeller(self::$permutations))->label($end);

--- a/tests/unit/ML/Supervised/LinearCombinationLabellerTest.php
+++ b/tests/unit/ML/Supervised/LinearCombinationLabellerTest.php
@@ -24,7 +24,7 @@ class LinearCombinationLabellerTest extends AbstractUnitTestCase
 
         self::$permutations = (new RestrictedPermutationWithRepetition())
             ->get(
-                [5, 8, 13, 21, 34],
+                [5, 8, 13, 21],
                 count($dimensions),
                 100
             );
@@ -88,8 +88,8 @@ class LinearCombinationLabellerTest extends AbstractUnitTestCase
             ->getBalance();
 
         $expected = [
-            Symbol::WHITE => 55,
-            Symbol::BLACK => -19,
+            Symbol::WHITE => 50,
+            Symbol::BLACK => -6,
         ];
 
         $label = (new LinearCombinationLabeller(self::$permutations))->balance(end($balance));
@@ -111,8 +111,8 @@ class LinearCombinationLabellerTest extends AbstractUnitTestCase
             ->getBalance();
 
         $expected = [
-            Symbol::WHITE => 29,
-            Symbol::BLACK => -29,
+            Symbol::WHITE => 16,
+            Symbol::BLACK => -16,
         ];
 
         $label = (new LinearCombinationLabeller(self::$permutations))->balance(end($balance));
@@ -132,8 +132,8 @@ class LinearCombinationLabellerTest extends AbstractUnitTestCase
             ->getBalance();
 
         $expected = [
-            Symbol::WHITE => 11.6,
-            Symbol::BLACK => -59.5,
+            Symbol::WHITE => 0,
+            Symbol::BLACK => -54.5,
         ];
 
         $label = (new LinearCombinationLabeller(self::$permutations))->balance(end($balance));
@@ -153,8 +153,8 @@ class LinearCombinationLabellerTest extends AbstractUnitTestCase
             ->getBalance();
 
         $expected = [
-            Symbol::WHITE => 47.7,
-            Symbol::BLACK => -40.06,
+            Symbol::WHITE => 39.5,
+            Symbol::BLACK => -31.06,
         ];
 
         $label = (new LinearCombinationLabeller(self::$permutations))->balance(end($balance));
@@ -175,7 +175,7 @@ class LinearCombinationLabellerTest extends AbstractUnitTestCase
 
         $expected = [
             Symbol::WHITE => 53.2,
-            Symbol::BLACK => -15.63,
+            Symbol::BLACK => -0.88,
         ];
 
         $label = (new LinearCombinationLabeller(self::$permutations))->balance(end($balance));
@@ -195,8 +195,8 @@ class LinearCombinationLabellerTest extends AbstractUnitTestCase
             ->getBalance();
 
         $expected = [
-            Symbol::WHITE => 34.07,
-            Symbol::BLACK => -16.39,
+            Symbol::WHITE => 24.19,
+            Symbol::BLACK => -9.89,
         ];
 
         $label = (new LinearCombinationLabeller(self::$permutations))->balance(end($balance));
@@ -217,7 +217,7 @@ class LinearCombinationLabellerTest extends AbstractUnitTestCase
 
         $end = end($balance);
 
-        $expected = [ 21, 8, 13, 8, 8, 8, 8, 8, 8, 5, 5 ];
+        $expected = [ 13, 8, 13, 8, 8, 8, 8, 8, 8, 8, 5, 5 ];
 
         $permutation = (new LinearCombinationLabeller(self::$permutations))
             ->extractPermutation($end, 2.95);
@@ -239,9 +239,9 @@ class LinearCombinationLabellerTest extends AbstractUnitTestCase
         $end = end($balance);
 
         $expected = [
-            'n' => 45,
-            'eval' => -16.39,
-            'weights' => [ 5, 5, 21, 5, 34, 5, 5, 5, 5, 5, 5 ],
+            'n' => 40,
+            'eval' => -9.89,
+            'weights' => [ 13, 5, 21, 5, 21, 5, 5, 5, 5, 5, 5, 5 ],
         ];
 
         $calc = (new LinearCombinationLabeller(self::$permutations))

--- a/tests/unit/ML/Supervised/Regression/LinearCombinationLabellerTest.php
+++ b/tests/unit/ML/Supervised/Regression/LinearCombinationLabellerTest.php
@@ -24,7 +24,7 @@ class LinearCombinationLabellerTest extends AbstractUnitTestCase
 
         self::$permutations = (new RestrictedPermutationWithRepetition())
             ->get(
-                [ 5, 8, 13, 21, 34],
+                [ 5, 8, 13, 21 ],
                 count($dimensions),
                 100
             );
@@ -90,8 +90,8 @@ class LinearCombinationLabellerTest extends AbstractUnitTestCase
             ->end();
 
         $expected = [
-            Symbol::WHITE => 60.0,
-            Symbol::BLACK => 34.0,
+            Symbol::WHITE => 55.0,
+            Symbol::BLACK => 21.0,
         ];
 
         $label = (new LinearCombinationLabeller(self::$permutations))
@@ -114,8 +114,8 @@ class LinearCombinationLabellerTest extends AbstractUnitTestCase
             ->end();
 
         $expected = [
-            Symbol::WHITE => 34.0,
-            Symbol::BLACK => 34.0,
+            Symbol::WHITE => 21.0,
+            Symbol::BLACK => 21.0,
         ];
 
         $label = (new LinearCombinationLabeller(self::$permutations))->label($end);
@@ -135,8 +135,8 @@ class LinearCombinationLabellerTest extends AbstractUnitTestCase
             ->end();
 
         $expected = [
-            Symbol::WHITE => 34.8,
-            Symbol::BLACK => 65.0,
+            Symbol::WHITE => 23.1,
+            Symbol::BLACK => 60.0,
         ];
 
         $label = (new LinearCombinationLabeller(self::$permutations))->label($end);
@@ -156,8 +156,8 @@ class LinearCombinationLabellerTest extends AbstractUnitTestCase
             ->end();
 
         $expected = [
-            Symbol::WHITE => 64.35,
-            Symbol::BLACK => 60.53,
+            Symbol::WHITE => 59.35,
+            Symbol::BLACK => 51.53,
         ];
 
         $label = (new LinearCombinationLabeller(self::$permutations))->label($end);
@@ -178,7 +178,7 @@ class LinearCombinationLabellerTest extends AbstractUnitTestCase
 
         $expected = [
             Symbol::WHITE => 67.2,
-            Symbol::BLACK => 55.0,
+            Symbol::BLACK => 47.36,
         ];
 
         $label = (new LinearCombinationLabeller(self::$permutations))->label($end);
@@ -198,8 +198,8 @@ class LinearCombinationLabellerTest extends AbstractUnitTestCase
             ->end();
 
         $expected = [
-            Symbol::WHITE => 57.85,
-            Symbol::BLACK => 43.04,
+            Symbol::WHITE => 51.91,
+            Symbol::BLACK => 38.36,
         ];
 
         $label = (new LinearCombinationLabeller(self::$permutations))->label($end);


### PR DESCRIPTION
Closes https://github.com/chesslablab/php-chess/issues/130 and https://github.com/chesslablab/php-chess/issues/131