### PR TITLE
Improve assertions

### DIFF
--- a/tests/functional/GameTest.php
+++ b/tests/functional/GameTest.php
@@ -23,10 +23,10 @@ class GameTest extends AbstractFunctionalTestCase
         $moves = array_values(array_filter($moves));
         for ($i = 0; $i < count($moves); ++$i) {
             $whiteMove = str_replace("\r", '', str_replace("\n", '', $moves[$i][0]));
-            $this->assertEquals(true, $game->play('w', $whiteMove));
+            $this->assertTrue($game->play('w', $whiteMove));
             if (isset($moves[$i][1])) {
                 $blackMove = str_replace("\r", '', str_replace("\n", '', $moves[$i][1]));
-                $this->assertEquals(true, $game->play('b', $blackMove));
+                $this->assertTrue($game->play('b', $blackMove));
             }
         }
     }

--- a/tests/unit/ArrayOfBoardsTest.php
+++ b/tests/unit/ArrayOfBoardsTest.php
@@ -18,17 +18,17 @@ class ArrayOfBoardsTest extends AbstractUnitTestCase
         $boards[] = new Board();
         $boards[] = new Board();
 
-        $this->assertEquals(true, $boards[0]->play(Convert::toStdObj(Symbol::WHITE, 'e4')));
-        $this->assertEquals(true, $boards[1]->play(Convert::toStdObj(Symbol::WHITE, 'e4')));
+        $this->assertTrue($boards[0]->play(Convert::toStdObj(Symbol::WHITE, 'e4')));
+        $this->assertTrue($boards[1]->play(Convert::toStdObj(Symbol::WHITE, 'e4')));
 
-        $this->assertEquals(true, $boards[0]->play(Convert::toStdObj(Symbol::BLACK, 'e5')));
-        $this->assertEquals(true, $boards[1]->play(Convert::toStdObj(Symbol::BLACK, 'e5')));
+        $this->assertTrue($boards[0]->play(Convert::toStdObj(Symbol::BLACK, 'e5')));
+        $this->assertTrue($boards[1]->play(Convert::toStdObj(Symbol::BLACK, 'e5')));
 
-        $this->assertEquals(true, $boards[0]->play(Convert::toStdObj(Symbol::WHITE, 'd4')));
-        $this->assertEquals(true, $boards[1]->play(Convert::toStdObj(Symbol::WHITE, 'd4')));
+        $this->assertTrue($boards[0]->play(Convert::toStdObj(Symbol::WHITE, 'd4')));
+        $this->assertTrue($boards[1]->play(Convert::toStdObj(Symbol::WHITE, 'd4')));
 
-        $this->assertEquals(true, $boards[0]->play(Convert::toStdObj(Symbol::BLACK, 'exd4')));
-        $this->assertEquals(true, $boards[1]->play(Convert::toStdObj(Symbol::BLACK, 'exd4')));
+        $this->assertTrue($boards[0]->play(Convert::toStdObj(Symbol::BLACK, 'exd4')));
+        $this->assertTrue($boards[1]->play(Convert::toStdObj(Symbol::BLACK, 'exd4')));
     }
 
     /**
@@ -42,24 +42,24 @@ class ArrayOfBoardsTest extends AbstractUnitTestCase
         $boards[] = new Board();
         $boards[] = new Board();
 
-        $this->assertEquals(true, $boards[0]->play(Convert::toStdObj(Symbol::WHITE, 'e4')));
-        $this->assertEquals(true, $boards[1]->play(Convert::toStdObj(Symbol::WHITE, 'e4')));
-        $this->assertEquals(true, $boards[2]->play(Convert::toStdObj(Symbol::WHITE, 'e4')));
-        $this->assertEquals(true, $boards[3]->play(Convert::toStdObj(Symbol::WHITE, 'e4')));
+        $this->assertTrue($boards[0]->play(Convert::toStdObj(Symbol::WHITE, 'e4')));
+        $this->assertTrue($boards[1]->play(Convert::toStdObj(Symbol::WHITE, 'e4')));
+        $this->assertTrue($boards[2]->play(Convert::toStdObj(Symbol::WHITE, 'e4')));
+        $this->assertTrue($boards[3]->play(Convert::toStdObj(Symbol::WHITE, 'e4')));
 
-        $this->assertEquals(true, $boards[0]->play(Convert::toStdObj(Symbol::BLACK, 'c5')));
-        $this->assertEquals(true, $boards[1]->play(Convert::toStdObj(Symbol::BLACK, 'c5')));
-        $this->assertEquals(true, $boards[2]->play(Convert::toStdObj(Symbol::BLACK, 'c5')));
-        $this->assertEquals(true, $boards[3]->play(Convert::toStdObj(Symbol::BLACK, 'c5')));
+        $this->assertTrue($boards[0]->play(Convert::toStdObj(Symbol::BLACK, 'c5')));
+        $this->assertTrue($boards[1]->play(Convert::toStdObj(Symbol::BLACK, 'c5')));
+        $this->assertTrue($boards[2]->play(Convert::toStdObj(Symbol::BLACK, 'c5')));
+        $this->assertTrue($boards[3]->play(Convert::toStdObj(Symbol::BLACK, 'c5')));
 
-        $this->assertEquals(true, $boards[0]->play(Convert::toStdObj(Symbol::WHITE, 'Nf3')));
-        $this->assertEquals(true, $boards[1]->play(Convert::toStdObj(Symbol::WHITE, 'Nf3')));
-        $this->assertEquals(true, $boards[2]->play(Convert::toStdObj(Symbol::WHITE, 'Nf3')));
-        $this->assertEquals(true, $boards[3]->play(Convert::toStdObj(Symbol::WHITE, 'Nf3')));
+        $this->assertTrue($boards[0]->play(Convert::toStdObj(Symbol::WHITE, 'Nf3')));
+        $this->assertTrue($boards[1]->play(Convert::toStdObj(Symbol::WHITE, 'Nf3')));
+        $this->assertTrue($boards[2]->play(Convert::toStdObj(Symbol::WHITE, 'Nf3')));
+        $this->assertTrue($boards[3]->play(Convert::toStdObj(Symbol::WHITE, 'Nf3')));
 
-        $this->assertEquals(true, $boards[0]->play(Convert::toStdObj(Symbol::BLACK, 'd6')));
-        $this->assertEquals(true, $boards[1]->play(Convert::toStdObj(Symbol::BLACK, 'd6')));
-        $this->assertEquals(true, $boards[2]->play(Convert::toStdObj(Symbol::BLACK, 'd6')));
-        $this->assertEquals(true, $boards[3]->play(Convert::toStdObj(Symbol::BLACK, 'd6')));
+        $this->assertTrue($boards[0]->play(Convert::toStdObj(Symbol::BLACK, 'd6')));
+        $this->assertTrue($boards[1]->play(Convert::toStdObj(Symbol::BLACK, 'd6')));
+        $this->assertTrue($boards[2]->play(Convert::toStdObj(Symbol::BLACK, 'd6')));
+        $this->assertTrue($boards[3]->play(Convert::toStdObj(Symbol::BLACK, 'd6')));
     }
 }

--- a/tests/unit/AsciiTest.php
+++ b/tests/unit/AsciiTest.php
@@ -40,7 +40,7 @@ class AsciiTest extends AbstractUnitTestCase
             0 => [ ' R ', ' N ', ' B ', ' Q ', ' K ', ' B ', ' N ', ' R ' ],
         ];
 
-        $this->assertEquals($expected, $array);
+        $this->assertSame($expected, $array);
     }
 
     /**
@@ -75,7 +75,7 @@ class AsciiTest extends AbstractUnitTestCase
         $board = (new Ascii())->toBoard($expected, Symbol::WHITE, $castling);
         $array = (new Ascii())->toArray($board);
 
-        $this->assertEquals($expected, $array);
+        $this->assertSame($expected, $array);
     }
 
     /**
@@ -98,7 +98,7 @@ class AsciiTest extends AbstractUnitTestCase
             0 => [ ' R ', ' . ', ' B ', ' Q ', ' . ', ' K ', ' N ', ' R ' ],
         ];
 
-        $this->assertEquals($expected, $array);
+        $this->assertSame($expected, $array);
     }
 
     /**
@@ -133,7 +133,7 @@ class AsciiTest extends AbstractUnitTestCase
         $board = (new Ascii())->toBoard($expected, Symbol::BLACK, $castling);
         $array = (new Ascii())->toArray($board);
 
-        $this->assertEquals($expected, $array);
+        $this->assertSame($expected, $array);
     }
 
     /**
@@ -156,7 +156,7 @@ class AsciiTest extends AbstractUnitTestCase
             0 => [ ' R ', ' . ', ' B ', ' Q ', ' . ', ' R ', ' K ', ' . ' ],
         ];
 
-        $this->assertEquals($expected, $array);
+        $this->assertSame($expected, $array);
     }
 
     /**
@@ -191,7 +191,7 @@ class AsciiTest extends AbstractUnitTestCase
         $board = (new Ascii())->toBoard($expected, Symbol::BLACK, $castling);
         $array = (new Ascii())->toArray($board);
 
-        $this->assertEquals($expected, $array);
+        $this->assertSame($expected, $array);
     }
 
     /**
@@ -214,7 +214,7 @@ class AsciiTest extends AbstractUnitTestCase
             0 => [ ' R ', ' . ', ' B ', ' Q ', ' K ', ' B ', ' N ', ' R ' ],
         ];
 
-        $this->assertEquals($expected, $array);
+        $this->assertSame($expected, $array);
     }
 
     /**
@@ -237,7 +237,7 @@ class AsciiTest extends AbstractUnitTestCase
             0 => [ ' R ', ' N ', ' B ', ' Q ', ' K ', ' B ', ' N ', ' R ' ],
         ];
 
-        $this->assertEquals($expected, $array);
+        $this->assertSame($expected, $array);
     }
 
     /**
@@ -259,7 +259,7 @@ class AsciiTest extends AbstractUnitTestCase
         $board = (new Ascii())->toBoard($expected, Symbol::WHITE);
         $array = (new Ascii())->toArray($board);
 
-        $this->assertEquals($expected, $array);
+        $this->assertSame($expected, $array);
     }
 
     /**
@@ -282,7 +282,7 @@ class AsciiTest extends AbstractUnitTestCase
             0 => [ ' R ', ' N ', ' B ', ' Q ', ' K ', ' B ', ' N ', ' R ' ],
         ];
 
-        $this->assertEquals($expected, $array);
+        $this->assertSame($expected, $array);
     }
 
     /**
@@ -304,7 +304,7 @@ class AsciiTest extends AbstractUnitTestCase
         $board = (new Ascii())->toBoard($expected, Symbol::WHITE);
         $array = (new Ascii())->toArray($board);
 
-        $this->assertEquals($expected, $array);
+        $this->assertSame($expected, $array);
     }
 
     /**
@@ -327,7 +327,7 @@ class AsciiTest extends AbstractUnitTestCase
             0 => [ ' R ', ' N ', ' B ', ' . ', ' K ', ' . ', ' . ', ' R ' ],
         ];
 
-        $this->assertEquals($expected, $array);
+        $this->assertSame($expected, $array);
     }
 
     /**
@@ -349,7 +349,7 @@ class AsciiTest extends AbstractUnitTestCase
         $board = (new Ascii())->toBoard($expected, Symbol::BLACK);
         $array = (new Ascii())->toArray($board);
 
-        $this->assertEquals($expected, $array);
+        $this->assertSame($expected, $array);
     }
 
     /**
@@ -373,7 +373,7 @@ class AsciiTest extends AbstractUnitTestCase
             0 => [ ' R ', ' N ', ' B ', ' . ', ' K ', ' . ', ' . ', ' R ' ],
         ];
 
-        $this->assertEquals($expected, $array);
+        $this->assertSame($expected, $array);
     }
 
     /**
@@ -398,7 +398,7 @@ class AsciiTest extends AbstractUnitTestCase
             0 => [ ' R ', ' N ', ' B ', ' . ', ' K ', ' . ', ' . ', ' R ' ],
         ];
 
-        $this->assertEquals($expected, $array);
+        $this->assertSame($expected, $array);
     }
 
     /**
@@ -421,7 +421,7 @@ class AsciiTest extends AbstractUnitTestCase
             0 => [ ' R ', ' . ', ' B ', ' Q ', ' K ', ' . ', ' N ', ' R ' ],
         ];
 
-        $this->assertEquals($expected, $array);
+        $this->assertSame($expected, $array);
     }
 
     /**
@@ -443,7 +443,7 @@ class AsciiTest extends AbstractUnitTestCase
         $board = (new Ascii())->toBoard($expected, Symbol::WHITE);
         $array = (new Ascii())->toArray($board);
 
-        $this->assertEquals($expected, $array);
+        $this->assertSame($expected, $array);
     }
 
     /**
@@ -451,7 +451,7 @@ class AsciiTest extends AbstractUnitTestCase
      */
     public function from_index_to_algebraic_0_0()
     {
-        $this->assertEquals('a1', (new Ascii())->fromIndexToAlgebraic(0, 0));
+        $this->assertSame('a1', (new Ascii())->fromIndexToAlgebraic(0, 0));
     }
 
     /**
@@ -459,7 +459,7 @@ class AsciiTest extends AbstractUnitTestCase
      */
     public function from_index_to_algebraic_1_0()
     {
-        $this->assertEquals('a2', (new Ascii())->fromIndexToAlgebraic(1, 0));
+        $this->assertSame('a2', (new Ascii())->fromIndexToAlgebraic(1, 0));
     }
 
     /**
@@ -467,7 +467,7 @@ class AsciiTest extends AbstractUnitTestCase
      */
     public function from_index_to_algebraic_6_7()
     {
-        $this->assertEquals('h7', (new Ascii())->fromIndexToAlgebraic(6, 7));
+        $this->assertSame('h7', (new Ascii())->fromIndexToAlgebraic(6, 7));
     }
 
     /**
@@ -475,7 +475,7 @@ class AsciiTest extends AbstractUnitTestCase
      */
     public function from_index_to_algebraic_7_7()
     {
-        $this->assertEquals('h8', (new Ascii())->fromIndexToAlgebraic(7, 7));
+        $this->assertSame('h8', (new Ascii())->fromIndexToAlgebraic(7, 7));
     }
 
     /**
@@ -483,7 +483,7 @@ class AsciiTest extends AbstractUnitTestCase
      */
     public function from_algebraic_to_index_a1()
     {
-        $this->assertEquals([0, 0], (new Ascii())->fromAlgebraicToIndex('a1'));
+        $this->assertSame([0, 0], (new Ascii())->fromAlgebraicToIndex('a1'));
     }
 
     /**
@@ -491,7 +491,7 @@ class AsciiTest extends AbstractUnitTestCase
      */
     public function from_algebraic_to_index_a2()
     {
-        $this->assertEquals([1, 0], (new Ascii())->fromAlgebraicToIndex('a2'));
+        $this->assertSame([1, 0], (new Ascii())->fromAlgebraicToIndex('a2'));
     }
 
     /**
@@ -499,7 +499,7 @@ class AsciiTest extends AbstractUnitTestCase
      */
     public function from_algebraic_to_index_h7()
     {
-        $this->assertEquals([6, 7], (new Ascii())->fromAlgebraicToIndex('h7'));
+        $this->assertSame([6, 7], (new Ascii())->fromAlgebraicToIndex('h7'));
     }
 
     /**
@@ -507,7 +507,7 @@ class AsciiTest extends AbstractUnitTestCase
      */
     public function from_algebraic_to_index_h8()
     {
-        $this->assertEquals([7, 7], (new Ascii())->fromAlgebraicToIndex('h8'));
+        $this->assertSame([7, 7], (new Ascii())->fromAlgebraicToIndex('h8'));
     }
 
     /**
@@ -541,7 +541,7 @@ class AsciiTest extends AbstractUnitTestCase
             ->setArrayElem(' . ', 'g1', $array)
             ->setArrayElem(' N ', 'f3', $array);
 
-        $this->assertEquals($expected, $array);
+        $this->assertSame($expected, $array);
     }
 
     /**
@@ -550,28 +550,28 @@ class AsciiTest extends AbstractUnitTestCase
     public function e4_e5_Nf3_Nc6_Bb5_a6_Ba4_b5_Bb3_Bb7_a4_Nf6_Nc3_g6_Qe2_d6_d3_Be7_Bg5_Qd7_O_O_O_O_O()
     {
         $board = new Board();
-        $this->assertEquals(true, $board->play(Convert::toStdObj(Symbol::WHITE, 'e4')));
-        $this->assertEquals(true, $board->play(Convert::toStdObj(Symbol::BLACK, 'e5')));
-        $this->assertEquals(true, $board->play(Convert::toStdObj(Symbol::WHITE, 'Nf3')));
-        $this->assertEquals(true, $board->play(Convert::toStdObj(Symbol::BLACK, 'Nc6')));
-        $this->assertEquals(true, $board->play(Convert::toStdObj(Symbol::WHITE, 'Bb5')));
-        $this->assertEquals(true, $board->play(Convert::toStdObj(Symbol::BLACK, 'a6')));
-        $this->assertEquals(true, $board->play(Convert::toStdObj(Symbol::WHITE, 'Ba4')));
-        $this->assertEquals(true, $board->play(Convert::toStdObj(Symbol::BLACK, 'b5')));
-        $this->assertEquals(true, $board->play(Convert::toStdObj(Symbol::WHITE, 'Bb3')));
-        $this->assertEquals(true, $board->play(Convert::toStdObj(Symbol::BLACK, 'Bb7')));
-        $this->assertEquals(true, $board->play(Convert::toStdObj(Symbol::WHITE, 'a4')));
-        $this->assertEquals(true, $board->play(Convert::toStdObj(Symbol::BLACK, 'Nf6')));
-        $this->assertEquals(true, $board->play(Convert::toStdObj(Symbol::WHITE, 'Nc3')));
-        $this->assertEquals(true, $board->play(Convert::toStdObj(Symbol::BLACK, 'g6')));
-        $this->assertEquals(true, $board->play(Convert::toStdObj(Symbol::WHITE, 'Qe2')));
-        $this->assertEquals(true, $board->play(Convert::toStdObj(Symbol::BLACK, 'd6')));
-        $this->assertEquals(true, $board->play(Convert::toStdObj(Symbol::WHITE, 'd3')));
-        $this->assertEquals(true, $board->play(Convert::toStdObj(Symbol::BLACK, 'Be7')));
-        $this->assertEquals(true, $board->play(Convert::toStdObj(Symbol::WHITE, 'Bg5')));
-        $this->assertEquals(true, $board->play(Convert::toStdObj(Symbol::BLACK, 'Qd7')));
-        $this->assertEquals(true, $board->play(Convert::toStdObj(Symbol::WHITE, 'O-O-O')));
-        $this->assertEquals(true, $board->play(Convert::toStdObj(Symbol::BLACK, 'O-O')));
+        $this->assertTrue($board->play(Convert::toStdObj(Symbol::WHITE, 'e4')));
+        $this->assertTrue($board->play(Convert::toStdObj(Symbol::BLACK, 'e5')));
+        $this->assertTrue($board->play(Convert::toStdObj(Symbol::WHITE, 'Nf3')));
+        $this->assertTrue($board->play(Convert::toStdObj(Symbol::BLACK, 'Nc6')));
+        $this->assertTrue($board->play(Convert::toStdObj(Symbol::WHITE, 'Bb5')));
+        $this->assertTrue($board->play(Convert::toStdObj(Symbol::BLACK, 'a6')));
+        $this->assertTrue($board->play(Convert::toStdObj(Symbol::WHITE, 'Ba4')));
+        $this->assertTrue($board->play(Convert::toStdObj(Symbol::BLACK, 'b5')));
+        $this->assertTrue($board->play(Convert::toStdObj(Symbol::WHITE, 'Bb3')));
+        $this->assertTrue($board->play(Convert::toStdObj(Symbol::BLACK, 'Bb7')));
+        $this->assertTrue($board->play(Convert::toStdObj(Symbol::WHITE, 'a4')));
+        $this->assertTrue($board->play(Convert::toStdObj(Symbol::BLACK, 'Nf6')));
+        $this->assertTrue($board->play(Convert::toStdObj(Symbol::WHITE, 'Nc3')));
+        $this->assertTrue($board->play(Convert::toStdObj(Symbol::BLACK, 'g6')));
+        $this->assertTrue($board->play(Convert::toStdObj(Symbol::WHITE, 'Qe2')));
+        $this->assertTrue($board->play(Convert::toStdObj(Symbol::BLACK, 'd6')));
+        $this->assertTrue($board->play(Convert::toStdObj(Symbol::WHITE, 'd3')));
+        $this->assertTrue($board->play(Convert::toStdObj(Symbol::BLACK, 'Be7')));
+        $this->assertTrue($board->play(Convert::toStdObj(Symbol::WHITE, 'Bg5')));
+        $this->assertTrue($board->play(Convert::toStdObj(Symbol::BLACK, 'Qd7')));
+        $this->assertTrue($board->play(Convert::toStdObj(Symbol::WHITE, 'O-O-O')));
+        $this->assertTrue($board->play(Convert::toStdObj(Symbol::BLACK, 'O-O')));
 
         $array = (new Ascii())->toArray($board);
 
@@ -586,7 +586,7 @@ class AsciiTest extends AbstractUnitTestCase
             0 => [ ' . ', ' . ', ' K ', ' R ', ' . ', ' . ', ' . ', ' R ' ],
         ];
 
-        $this->assertEquals($expected, $array);
+        $this->assertSame($expected, $array);
     }
 
     /**
@@ -595,23 +595,23 @@ class AsciiTest extends AbstractUnitTestCase
     public function e4_e5_Nf3_Nc6_Bc4_h6_h4_g5_hxg5_hxg5_Rxh8_Bg7_d3_Bxh8_Qe2_Nge7_c3()
     {
         $board = new Board();
-        $this->assertEquals(true, $board->play(Convert::toStdObj(Symbol::WHITE, 'e4')));
-        $this->assertEquals(true, $board->play(Convert::toStdObj(Symbol::BLACK, 'e5')));
-        $this->assertEquals(true, $board->play(Convert::toStdObj(Symbol::WHITE, 'Nf3')));
-        $this->assertEquals(true, $board->play(Convert::toStdObj(Symbol::BLACK, 'Nc6')));
-        $this->assertEquals(true, $board->play(Convert::toStdObj(Symbol::WHITE, 'Bc4')));
-        $this->assertEquals(true, $board->play(Convert::toStdObj(Symbol::BLACK, 'h6')));
-        $this->assertEquals(true, $board->play(Convert::toStdObj(Symbol::WHITE, 'h4')));
-        $this->assertEquals(true, $board->play(Convert::toStdObj(Symbol::BLACK, 'g5')));
-        $this->assertEquals(true, $board->play(Convert::toStdObj(Symbol::WHITE, 'hxg5')));
-        $this->assertEquals(true, $board->play(Convert::toStdObj(Symbol::BLACK, 'hxg5')));
-        $this->assertEquals(true, $board->play(Convert::toStdObj(Symbol::WHITE, 'Rxh8')));
-        $this->assertEquals(true, $board->play(Convert::toStdObj(Symbol::BLACK, 'Bg7')));
-        $this->assertEquals(true, $board->play(Convert::toStdObj(Symbol::WHITE, 'd3')));
-        $this->assertEquals(true, $board->play(Convert::toStdObj(Symbol::BLACK, 'Bxh8')));
-        $this->assertEquals(true, $board->play(Convert::toStdObj(Symbol::WHITE, 'Qe2')));
-        $this->assertEquals(true, $board->play(Convert::toStdObj(Symbol::BLACK, 'Nge7')));
-        $this->assertEquals(true, $board->play(Convert::toStdObj(Symbol::WHITE, 'c3')));
+        $this->assertTrue($board->play(Convert::toStdObj(Symbol::WHITE, 'e4')));
+        $this->assertTrue($board->play(Convert::toStdObj(Symbol::BLACK, 'e5')));
+        $this->assertTrue($board->play(Convert::toStdObj(Symbol::WHITE, 'Nf3')));
+        $this->assertTrue($board->play(Convert::toStdObj(Symbol::BLACK, 'Nc6')));
+        $this->assertTrue($board->play(Convert::toStdObj(Symbol::WHITE, 'Bc4')));
+        $this->assertTrue($board->play(Convert::toStdObj(Symbol::BLACK, 'h6')));
+        $this->assertTrue($board->play(Convert::toStdObj(Symbol::WHITE, 'h4')));
+        $this->assertTrue($board->play(Convert::toStdObj(Symbol::BLACK, 'g5')));
+        $this->assertTrue($board->play(Convert::toStdObj(Symbol::WHITE, 'hxg5')));
+        $this->assertTrue($board->play(Convert::toStdObj(Symbol::BLACK, 'hxg5')));
+        $this->assertTrue($board->play(Convert::toStdObj(Symbol::WHITE, 'Rxh8')));
+        $this->assertTrue($board->play(Convert::toStdObj(Symbol::BLACK, 'Bg7')));
+        $this->assertTrue($board->play(Convert::toStdObj(Symbol::WHITE, 'd3')));
+        $this->assertTrue($board->play(Convert::toStdObj(Symbol::BLACK, 'Bxh8')));
+        $this->assertTrue($board->play(Convert::toStdObj(Symbol::WHITE, 'Qe2')));
+        $this->assertTrue($board->play(Convert::toStdObj(Symbol::BLACK, 'Nge7')));
+        $this->assertTrue($board->play(Convert::toStdObj(Symbol::WHITE, 'c3')));
 
         $array = (new Ascii())->toArray($board);
 
@@ -626,7 +626,7 @@ class AsciiTest extends AbstractUnitTestCase
             0 => [ ' R ', ' N ', ' B ', ' . ', ' K ', ' . ', ' . ', ' . ' ],
         ];
 
-        $this->assertEquals($expected, $array);
+        $this->assertSame($expected, $array);
     }
 
     /**
@@ -635,24 +635,24 @@ class AsciiTest extends AbstractUnitTestCase
     public function e4_e5_Nf3_Nc6_Bc4_h6_h4_g5_hxg5_hxg5_Rxh8_Bg7_d3_Bxh8_Qe2_Nge7_c3_g4()
     {
         $board = new Board();
-        $this->assertEquals(true, $board->play(Convert::toStdObj(Symbol::WHITE, 'e4')));
-        $this->assertEquals(true, $board->play(Convert::toStdObj(Symbol::BLACK, 'e5')));
-        $this->assertEquals(true, $board->play(Convert::toStdObj(Symbol::WHITE, 'Nf3')));
-        $this->assertEquals(true, $board->play(Convert::toStdObj(Symbol::BLACK, 'Nc6')));
-        $this->assertEquals(true, $board->play(Convert::toStdObj(Symbol::WHITE, 'Bc4')));
-        $this->assertEquals(true, $board->play(Convert::toStdObj(Symbol::BLACK, 'h6')));
-        $this->assertEquals(true, $board->play(Convert::toStdObj(Symbol::WHITE, 'h4')));
-        $this->assertEquals(true, $board->play(Convert::toStdObj(Symbol::BLACK, 'g5')));
-        $this->assertEquals(true, $board->play(Convert::toStdObj(Symbol::WHITE, 'hxg5')));
-        $this->assertEquals(true, $board->play(Convert::toStdObj(Symbol::BLACK, 'hxg5')));
-        $this->assertEquals(true, $board->play(Convert::toStdObj(Symbol::WHITE, 'Rxh8')));
-        $this->assertEquals(true, $board->play(Convert::toStdObj(Symbol::BLACK, 'Bg7')));
-        $this->assertEquals(true, $board->play(Convert::toStdObj(Symbol::WHITE, 'd3')));
-        $this->assertEquals(true, $board->play(Convert::toStdObj(Symbol::BLACK, 'Bxh8')));
-        $this->assertEquals(true, $board->play(Convert::toStdObj(Symbol::WHITE, 'Qe2')));
-        $this->assertEquals(true, $board->play(Convert::toStdObj(Symbol::BLACK, 'Nge7')));
-        $this->assertEquals(true, $board->play(Convert::toStdObj(Symbol::WHITE, 'c3')));
-        $this->assertEquals(true, $board->play(Convert::toStdObj(Symbol::BLACK, 'g4')));
+        $this->assertTrue($board->play(Convert::toStdObj(Symbol::WHITE, 'e4')));
+        $this->assertTrue($board->play(Convert::toStdObj(Symbol::BLACK, 'e5')));
+        $this->assertTrue($board->play(Convert::toStdObj(Symbol::WHITE, 'Nf3')));
+        $this->assertTrue($board->play(Convert::toStdObj(Symbol::BLACK, 'Nc6')));
+        $this->assertTrue($board->play(Convert::toStdObj(Symbol::WHITE, 'Bc4')));
+        $this->assertTrue($board->play(Convert::toStdObj(Symbol::BLACK, 'h6')));
+        $this->assertTrue($board->play(Convert::toStdObj(Symbol::WHITE, 'h4')));
+        $this->assertTrue($board->play(Convert::toStdObj(Symbol::BLACK, 'g5')));
+        $this->assertTrue($board->play(Convert::toStdObj(Symbol::WHITE, 'hxg5')));
+        $this->assertTrue($board->play(Convert::toStdObj(Symbol::BLACK, 'hxg5')));
+        $this->assertTrue($board->play(Convert::toStdObj(Symbol::WHITE, 'Rxh8')));
+        $this->assertTrue($board->play(Convert::toStdObj(Symbol::BLACK, 'Bg7')));
+        $this->assertTrue($board->play(Convert::toStdObj(Symbol::WHITE, 'd3')));
+        $this->assertTrue($board->play(Convert::toStdObj(Symbol::BLACK, 'Bxh8')));
+        $this->assertTrue($board->play(Convert::toStdObj(Symbol::WHITE, 'Qe2')));
+        $this->assertTrue($board->play(Convert::toStdObj(Symbol::BLACK, 'Nge7')));
+        $this->assertTrue($board->play(Convert::toStdObj(Symbol::WHITE, 'c3')));
+        $this->assertTrue($board->play(Convert::toStdObj(Symbol::BLACK, 'g4')));
 
 
         $array = (new Ascii())->toArray($board);
@@ -668,6 +668,6 @@ class AsciiTest extends AbstractUnitTestCase
             0 => [ ' R ', ' N ', ' B ', ' . ', ' K ', ' . ', ' . ', ' . ' ],
         ];
 
-        $this->assertEquals($expected, $array);
+        $this->assertSame($expected, $array);
     }
 }

--- a/tests/unit/Board/IllegalMovesTest.php
+++ b/tests/unit/Board/IllegalMovesTest.php
@@ -24,11 +24,11 @@ class IllegalMovesTest extends AbstractUnitTestCase
     {
         $board = new Board();
 
-        $this->assertEquals($board->getTurn(), Symbol::WHITE);
-        $this->assertEquals(true, $board->play(Convert::toStdObj(Symbol::WHITE, 'e4')));
-        $this->assertEquals($board->getTurn(), Symbol::BLACK);
-        $this->assertEquals(true, $board->play(Convert::toStdObj(Symbol::BLACK, 'e5')));
-        $this->assertEquals($board->getTurn(), Symbol::WHITE);
+        $this->assertSame($board->getTurn(), Symbol::WHITE);
+        $this->assertTrue($board->play(Convert::toStdObj(Symbol::WHITE, 'e4')));
+        $this->assertSame($board->getTurn(), Symbol::BLACK);
+        $this->assertTrue($board->play(Convert::toStdObj(Symbol::BLACK, 'e5')));
+        $this->assertSame($board->getTurn(), Symbol::WHITE);
     }
 
     /**
@@ -38,22 +38,22 @@ class IllegalMovesTest extends AbstractUnitTestCase
     {
         $board = new Board();
 
-        $this->assertEquals($board->getTurn(), Symbol::WHITE);
-        $this->assertEquals(false, $board->play(Convert::toStdObj(Symbol::BLACK, 'e4')));
-        $this->assertEquals($board->getTurn(), Symbol::WHITE);
-        $this->assertEquals(false, $board->play(Convert::toStdObj(Symbol::WHITE, 'O-O')));
-        $this->assertEquals($board->getTurn(), Symbol::WHITE);
-        $this->assertEquals(false, $board->play(Convert::toStdObj(Symbol::WHITE, 'O-O-O')));
-        $this->assertEquals($board->getTurn(), Symbol::WHITE);
-        $this->assertEquals(true, $board->play(Convert::toStdObj(Symbol::WHITE, 'e4')));
-        $this->assertEquals($board->getTurn(), Symbol::BLACK);
-        $this->assertEquals(false, $board->play(Convert::toStdObj(Symbol::WHITE, 'e5')));
-        $this->assertEquals($board->getTurn(), Symbol::BLACK);
-        $this->assertEquals(false, $board->play(Convert::toStdObj(Symbol::WHITE, 'Nf3')));
-        $this->assertEquals($board->getTurn(), Symbol::BLACK);
-        $this->assertEquals(true, $board->play(Convert::toStdObj(Symbol::BLACK, 'e5')));
-        $this->assertEquals($board->getTurn(), Symbol::WHITE);
-        $this->assertEquals(false, $board->play(Convert::toStdObj(Symbol::BLACK, 'Nc6')));
+        $this->assertSame($board->getTurn(), Symbol::WHITE);
+        $this->assertFalse($board->play(Convert::toStdObj(Symbol::BLACK, 'e4')));
+        $this->assertSame($board->getTurn(), Symbol::WHITE);
+        $this->assertFalse($board->play(Convert::toStdObj(Symbol::WHITE, 'O-O')));
+        $this->assertSame($board->getTurn(), Symbol::WHITE);
+        $this->assertFalse($board->play(Convert::toStdObj(Symbol::WHITE, 'O-O-O')));
+        $this->assertSame($board->getTurn(), Symbol::WHITE);
+        $this->assertTrue($board->play(Convert::toStdObj(Symbol::WHITE, 'e4')));
+        $this->assertSame($board->getTurn(), Symbol::BLACK);
+        $this->assertFalse($board->play(Convert::toStdObj(Symbol::WHITE, 'e5')));
+        $this->assertSame($board->getTurn(), Symbol::BLACK);
+        $this->assertFalse($board->play(Convert::toStdObj(Symbol::WHITE, 'Nf3')));
+        $this->assertSame($board->getTurn(), Symbol::BLACK);
+        $this->assertTrue($board->play(Convert::toStdObj(Symbol::BLACK, 'e5')));
+        $this->assertSame($board->getTurn(), Symbol::WHITE);
+        $this->assertFalse($board->play(Convert::toStdObj(Symbol::BLACK, 'Nc6')));
     }
 
     /**
@@ -62,7 +62,7 @@ class IllegalMovesTest extends AbstractUnitTestCase
     public function Qg5()
     {
         $board = new Board();
-        $this->assertEquals(false, $board->play(Convert::toStdObj(Symbol::BLACK, 'Qg5')));
+        $this->assertFalse($board->play(Convert::toStdObj(Symbol::BLACK, 'Qg5')));
     }
 
     /**
@@ -71,7 +71,7 @@ class IllegalMovesTest extends AbstractUnitTestCase
     public function Ra6()
     {
         $board = new Board();
-        $this->assertEquals(false, $board->play(Convert::toStdObj(Symbol::WHITE, 'Ra6')));
+        $this->assertFalse($board->play(Convert::toStdObj(Symbol::WHITE, 'Ra6')));
     }
 
     /**
@@ -80,7 +80,7 @@ class IllegalMovesTest extends AbstractUnitTestCase
     public function Rxa6()
     {
         $board = new Board();
-        $this->assertEquals(false, $board->play(Convert::toStdObj(Symbol::BLACK, 'Rxa6')));
+        $this->assertFalse($board->play(Convert::toStdObj(Symbol::BLACK, 'Rxa6')));
     }
 
     /**
@@ -89,7 +89,7 @@ class IllegalMovesTest extends AbstractUnitTestCase
     public function Bxe5()
     {
         $board = new Board();
-        $this->assertEquals(false, $board->play(Convert::toStdObj(Symbol::WHITE, 'Bxe5')));
+        $this->assertFalse($board->play(Convert::toStdObj(Symbol::WHITE, 'Bxe5')));
     }
 
     /**
@@ -98,7 +98,7 @@ class IllegalMovesTest extends AbstractUnitTestCase
     public function exd4()
     {
         $board = new Board();
-        $this->assertEquals(false, $board->play(Convert::toStdObj(Symbol::WHITE, 'exd4')));
+        $this->assertFalse($board->play(Convert::toStdObj(Symbol::WHITE, 'exd4')));
     }
 
     /**
@@ -107,7 +107,7 @@ class IllegalMovesTest extends AbstractUnitTestCase
     public function Nxd2()
     {
         $board = new Board();
-        $this->assertEquals(false, $board->play(Convert::toStdObj(Symbol::WHITE, 'Nxd2')));
+        $this->assertFalse($board->play(Convert::toStdObj(Symbol::WHITE, 'Nxd2')));
     }
 
     /**
@@ -116,7 +116,7 @@ class IllegalMovesTest extends AbstractUnitTestCase
     public function Nxc3()
     {
         $board = new Board();
-        $this->assertEquals(false, $board->play(Convert::toStdObj(Symbol::WHITE, 'Nxc3')));
+        $this->assertFalse($board->play(Convert::toStdObj(Symbol::WHITE, 'Nxc3')));
     }
 
     /**
@@ -125,7 +125,7 @@ class IllegalMovesTest extends AbstractUnitTestCase
     public function white_O_O()
     {
         $board = new Board();
-        $this->assertEquals(false, $board->play(Convert::toStdObj(Symbol::WHITE, 'O-O')));
+        $this->assertFalse($board->play(Convert::toStdObj(Symbol::WHITE, 'O-O')));
     }
 
     /**
@@ -134,7 +134,7 @@ class IllegalMovesTest extends AbstractUnitTestCase
     public function white_O_O_O()
     {
         $board = new Board();
-        $this->assertEquals(false, $board->play(Convert::toStdObj(Symbol::WHITE, 'O-O-O')));
+        $this->assertFalse($board->play(Convert::toStdObj(Symbol::WHITE, 'O-O-O')));
     }
 
     /**
@@ -144,7 +144,7 @@ class IllegalMovesTest extends AbstractUnitTestCase
     {
         $board = new Board();
         $board->play(Convert::toStdObj(Symbol::WHITE, 'e4'));
-        $this->assertEquals(false, $board->play(Convert::toStdObj(Symbol::BLACK, 'O-O')));
+        $this->assertFalse($board->play(Convert::toStdObj(Symbol::BLACK, 'O-O')));
     }
 
     /**
@@ -182,7 +182,7 @@ class IllegalMovesTest extends AbstractUnitTestCase
 
         $board = new Board($pieces, $castling);
 
-        $this->assertEquals(false, $board->play(Convert::toStdObj(Symbol::WHITE, 'Kf4')));
+        $this->assertFalse($board->play(Convert::toStdObj(Symbol::WHITE, 'Kf4')));
     }
 
     /**
@@ -220,7 +220,7 @@ class IllegalMovesTest extends AbstractUnitTestCase
 
         $board = new Board($pieces, $castling);
 
-        $this->assertEquals(false, $board->play(Convert::toStdObj(Symbol::WHITE, 'Kf4')));
+        $this->assertFalse($board->play(Convert::toStdObj(Symbol::WHITE, 'Kf4')));
     }
 
     /**
@@ -258,7 +258,7 @@ class IllegalMovesTest extends AbstractUnitTestCase
 
         $board = new Board($pieces, $castling);
 
-        $this->assertEquals(false, $board->play(Convert::toStdObj(Symbol::WHITE, 'Kf2')));
+        $this->assertFalse($board->play(Convert::toStdObj(Symbol::WHITE, 'Kf2')));
     }
 
     /**
@@ -296,7 +296,7 @@ class IllegalMovesTest extends AbstractUnitTestCase
 
         $board = new Board($pieces, $castling);
 
-        $this->assertEquals(false, $board->play(Convert::toStdObj(Symbol::WHITE, 'Re7')));
+        $this->assertFalse($board->play(Convert::toStdObj(Symbol::WHITE, 'Re7')));
     }
 
     /**
@@ -334,7 +334,7 @@ class IllegalMovesTest extends AbstractUnitTestCase
 
         $board = new Board($pieces, $castling);
 
-        $this->assertEquals(false, $board->play(Convert::toStdObj(Symbol::WHITE, 'a4')));
+        $this->assertFalse($board->play(Convert::toStdObj(Symbol::WHITE, 'a4')));
     }
 
     /**
@@ -372,7 +372,7 @@ class IllegalMovesTest extends AbstractUnitTestCase
 
         $board = new Board($pieces, $castling);
 
-        $this->assertEquals(false, $board->play(Convert::toStdObj(Symbol::WHITE, 'Kxf2')));
+        $this->assertFalse($board->play(Convert::toStdObj(Symbol::WHITE, 'Kxf2')));
     }
 
     /**
@@ -387,7 +387,7 @@ class IllegalMovesTest extends AbstractUnitTestCase
         $board->play(Convert::toStdObj(Symbol::WHITE, 'Nf3'));
         $board->play(Convert::toStdObj(Symbol::BLACK, 'Nc6'));
 
-        $this->assertEquals(false, $board->play(Convert::toStdObj(Symbol::WHITE, 'O-O')));
+        $this->assertFalse($board->play(Convert::toStdObj(Symbol::WHITE, 'O-O')));
     }
 
     /**
@@ -404,7 +404,7 @@ class IllegalMovesTest extends AbstractUnitTestCase
         $board->play(Convert::toStdObj(Symbol::WHITE, 'Bb5'));
         $board->play(Convert::toStdObj(Symbol::BLACK, 'Nf6'));
 
-        $this->assertEquals(false, $board->play(Convert::toStdObj(Symbol::WHITE, 'O-O-O')));
+        $this->assertFalse($board->play(Convert::toStdObj(Symbol::WHITE, 'O-O-O')));
     }
 
     /**
@@ -447,7 +447,7 @@ class IllegalMovesTest extends AbstractUnitTestCase
 
         $board = new Board($pieces, $castling);
 
-        $this->assertEquals(false, $board->play(Convert::toStdObj(Symbol::WHITE, 'O-O')));
+        $this->assertFalse($board->play(Convert::toStdObj(Symbol::WHITE, 'O-O')));
     }
 
     /**
@@ -490,7 +490,7 @@ class IllegalMovesTest extends AbstractUnitTestCase
 
         $board = new Board($pieces, $castling);
 
-        $this->assertEquals(false, $board->play(Convert::toStdObj(Symbol::WHITE, 'O-O')));
+        $this->assertFalse($board->play(Convert::toStdObj(Symbol::WHITE, 'O-O')));
     }
 
     /**
@@ -532,7 +532,7 @@ class IllegalMovesTest extends AbstractUnitTestCase
 
         $board = new Board($pieces, $castling);
 
-        $this->assertEquals(false, $board->play(Convert::toStdObj(Symbol::WHITE, 'O-O')));
+        $this->assertFalse($board->play(Convert::toStdObj(Symbol::WHITE, 'O-O')));
     }
 
     /**
@@ -574,7 +574,7 @@ class IllegalMovesTest extends AbstractUnitTestCase
 
         $board = new Board($pieces, $castling);
 
-        $this->assertEquals(false, $board->play(Convert::toStdObj(Symbol::WHITE, 'O-O-O')));
+        $this->assertFalse($board->play(Convert::toStdObj(Symbol::WHITE, 'O-O-O')));
     }
 
     /**
@@ -616,8 +616,8 @@ class IllegalMovesTest extends AbstractUnitTestCase
 
         $board = new Board($pieces, $castling);
 
-        $this->assertEquals(false, $board->play(Convert::toStdObj(Symbol::WHITE, 'O-O')));
-        $this->assertEquals(false, $board->play(Convert::toStdObj(Symbol::WHITE, 'O-O-O')));
+        $this->assertFalse($board->play(Convert::toStdObj(Symbol::WHITE, 'O-O')));
+        $this->assertFalse($board->play(Convert::toStdObj(Symbol::WHITE, 'O-O-O')));
     }
 
     /**
@@ -659,8 +659,8 @@ class IllegalMovesTest extends AbstractUnitTestCase
 
         $board = new Board($pieces, $castling);
 
-        $this->assertEquals(false, $board->play(Convert::toStdObj(Symbol::WHITE, 'O-O')));
-        $this->assertEquals(false, $board->play(Convert::toStdObj(Symbol::WHITE, 'O-O-O')));
+        $this->assertFalse($board->play(Convert::toStdObj(Symbol::WHITE, 'O-O')));
+        $this->assertFalse($board->play(Convert::toStdObj(Symbol::WHITE, 'O-O-O')));
     }
 
     /**
@@ -702,7 +702,7 @@ class IllegalMovesTest extends AbstractUnitTestCase
 
         $board = new Board($pieces, $castling);
 
-        $this->assertEquals(false, $board->play(Convert::toStdObj(Symbol::WHITE, 'O-O-O')));
+        $this->assertFalse($board->play(Convert::toStdObj(Symbol::WHITE, 'O-O-O')));
     }
 
     /**
@@ -744,11 +744,11 @@ class IllegalMovesTest extends AbstractUnitTestCase
 
         $board = new Board($pieces, $castling);
 
-        $this->assertEquals(true, $board->play(Convert::toStdObj(Symbol::WHITE, 'Kf1')));
-        $this->assertEquals(true, $board->play(Convert::toStdObj(Symbol::BLACK, 'Nf6')));
-        $this->assertEquals(true, $board->play(Convert::toStdObj(Symbol::WHITE, 'Ke1')));
-        $this->assertEquals(true, $board->play(Convert::toStdObj(Symbol::BLACK, 'Nd7')));
-        $this->assertEquals(false, $board->play(Convert::toStdObj(Symbol::WHITE, 'O-O')));
+        $this->assertTrue($board->play(Convert::toStdObj(Symbol::WHITE, 'Kf1')));
+        $this->assertTrue($board->play(Convert::toStdObj(Symbol::BLACK, 'Nf6')));
+        $this->assertTrue($board->play(Convert::toStdObj(Symbol::WHITE, 'Ke1')));
+        $this->assertTrue($board->play(Convert::toStdObj(Symbol::BLACK, 'Nd7')));
+        $this->assertFalse($board->play(Convert::toStdObj(Symbol::WHITE, 'O-O')));
     }
 
     /**
@@ -790,11 +790,11 @@ class IllegalMovesTest extends AbstractUnitTestCase
 
         $board = new Board($pieces, $castling);
 
-        $this->assertEquals(true, $board->play(Convert::toStdObj(Symbol::WHITE, 'Rg1')));
-        $this->assertEquals(true, $board->play(Convert::toStdObj(Symbol::BLACK, 'Nf6')));
-        $this->assertEquals(true, $board->play(Convert::toStdObj(Symbol::WHITE, 'Rh1')));
-        $this->assertEquals(true, $board->play(Convert::toStdObj(Symbol::BLACK, 'Nd7')));
-        $this->assertEquals(false, $board->play(Convert::toStdObj(Symbol::WHITE, 'O-O')));
+        $this->assertTrue($board->play(Convert::toStdObj(Symbol::WHITE, 'Rg1')));
+        $this->assertTrue($board->play(Convert::toStdObj(Symbol::BLACK, 'Nf6')));
+        $this->assertTrue($board->play(Convert::toStdObj(Symbol::WHITE, 'Rh1')));
+        $this->assertTrue($board->play(Convert::toStdObj(Symbol::BLACK, 'Nd7')));
+        $this->assertFalse($board->play(Convert::toStdObj(Symbol::WHITE, 'O-O')));
     }
 
     /**
@@ -817,8 +817,8 @@ class IllegalMovesTest extends AbstractUnitTestCase
         $board->play(Convert::toStdObj(Symbol::WHITE, 'Nc3'));
         $board->play(Convert::toStdObj(Symbol::BLACK, 'Ke8'));
 
-        $this->assertEquals(false, $board->play(Convert::toStdObj(Symbol::WHITE, 'O-O')));
-        $this->assertEquals(false, $board->play(Convert::toStdObj(Symbol::BLACK, 'O-O')));
+        $this->assertFalse($board->play(Convert::toStdObj(Symbol::WHITE, 'O-O')));
+        $this->assertFalse($board->play(Convert::toStdObj(Symbol::BLACK, 'O-O')));
     }
 
     /**
@@ -870,8 +870,8 @@ class IllegalMovesTest extends AbstractUnitTestCase
 
         $board = new Board($pieces, $castling);
 
-        $this->assertEquals(true, $board->play(Convert::toStdObj(Symbol::WHITE, 'Nf3')));
-        $this->assertEquals(false, $board->play(Convert::toStdObj(Symbol::BLACK, 'O-O')));
+        $this->assertTrue($board->play(Convert::toStdObj(Symbol::WHITE, 'Nf3')));
+        $this->assertFalse($board->play(Convert::toStdObj(Symbol::BLACK, 'O-O')));
     }
 
     /**
@@ -881,22 +881,22 @@ class IllegalMovesTest extends AbstractUnitTestCase
     {
         $board = new Board();
 
-        $this->assertEquals(false, $board->play(Convert::toStdObj(Symbol::WHITE, 'O-O')));
-        $this->assertEquals(false, $board->play(Convert::toStdObj(Symbol::WHITE, 'O-O-O')));
-        $this->assertEquals(false, $board->play(Convert::toStdObj(Symbol::WHITE, 'e5')));
+        $this->assertFalse($board->play(Convert::toStdObj(Symbol::WHITE, 'O-O')));
+        $this->assertFalse($board->play(Convert::toStdObj(Symbol::WHITE, 'O-O-O')));
+        $this->assertFalse($board->play(Convert::toStdObj(Symbol::WHITE, 'e5')));
 
-        $this->assertEquals(true, $board->play(Convert::toStdObj(Symbol::WHITE, 'e4')));
-        $this->assertEquals(true, $board->play(Convert::toStdObj(Symbol::BLACK, 'e5')));
+        $this->assertTrue($board->play(Convert::toStdObj(Symbol::WHITE, 'e4')));
+        $this->assertTrue($board->play(Convert::toStdObj(Symbol::BLACK, 'e5')));
 
-        $this->assertEquals(true, $board->play(Convert::toStdObj(Symbol::WHITE, 'Nf3')));
-        $this->assertEquals(true, $board->play(Convert::toStdObj(Symbol::BLACK, 'Nc6')));
+        $this->assertTrue($board->play(Convert::toStdObj(Symbol::WHITE, 'Nf3')));
+        $this->assertTrue($board->play(Convert::toStdObj(Symbol::BLACK, 'Nc6')));
 
-        $this->assertEquals(false, $board->play(Convert::toStdObj(Symbol::WHITE, 'Ra2')));
-        $this->assertEquals(false, $board->play(Convert::toStdObj(Symbol::WHITE, 'Ra3')));
-        $this->assertEquals(false, $board->play(Convert::toStdObj(Symbol::WHITE, 'Ra4')));
-        $this->assertEquals(false, $board->play(Convert::toStdObj(Symbol::WHITE, 'Ra5')));
-        $this->assertEquals(false, $board->play(Convert::toStdObj(Symbol::WHITE, 'Ra6')));
-        $this->assertEquals(false, $board->play(Convert::toStdObj(Symbol::WHITE, 'Ra7')));
-        $this->assertEquals(false, $board->play(Convert::toStdObj(Symbol::WHITE, 'Ra8')));
+        $this->assertFalse($board->play(Convert::toStdObj(Symbol::WHITE, 'Ra2')));
+        $this->assertFalse($board->play(Convert::toStdObj(Symbol::WHITE, 'Ra3')));
+        $this->assertFalse($board->play(Convert::toStdObj(Symbol::WHITE, 'Ra4')));
+        $this->assertFalse($board->play(Convert::toStdObj(Symbol::WHITE, 'Ra5')));
+        $this->assertFalse($board->play(Convert::toStdObj(Symbol::WHITE, 'Ra6')));
+        $this->assertFalse($board->play(Convert::toStdObj(Symbol::WHITE, 'Ra7')));
+        $this->assertFalse($board->play(Convert::toStdObj(Symbol::WHITE, 'Ra8')));
     }
 }

--- a/tests/unit/Board/LegalMovesTest.php
+++ b/tests/unit/Board/LegalMovesTest.php
@@ -70,7 +70,7 @@ class LegalMovesTest extends AbstractUnitTestCase
 
         $board = new Board($pieces, $castling);
 
-        $this->assertEquals(true, $board->play(Convert::toStdObj(Symbol::WHITE, 'Ra6')));
+        $this->assertTrue($board->play(Convert::toStdObj(Symbol::WHITE, 'Ra6')));
     }
 
     /**
@@ -102,7 +102,7 @@ class LegalMovesTest extends AbstractUnitTestCase
 
         $board = new Board($pieces, $castling);
 
-        $this->assertEquals(true, $board->play(Convert::toStdObj(Symbol::WHITE, 'Rxa6')));
+        $this->assertTrue($board->play(Convert::toStdObj(Symbol::WHITE, 'Rxa6')));
     }
 
     /**
@@ -135,7 +135,7 @@ class LegalMovesTest extends AbstractUnitTestCase
         $board = new Board($pieces, $castling);
         $board->setTurn(Symbol::BLACK);
 
-        $this->assertEquals(true, $board->play(Convert::toStdObj(Symbol::BLACK, 'h6')));
+        $this->assertTrue($board->play(Convert::toStdObj(Symbol::BLACK, 'h6')));
     }
 
     /**
@@ -169,7 +169,7 @@ class LegalMovesTest extends AbstractUnitTestCase
         $board = new Board($pieces, $castling);
         $board->setTurn(Symbol::BLACK);
 
-        $this->assertEquals(true, $board->play(Convert::toStdObj(Symbol::BLACK, 'hxg6')));
+        $this->assertTrue($board->play(Convert::toStdObj(Symbol::BLACK, 'hxg6')));
     }
 
     /**
@@ -178,7 +178,7 @@ class LegalMovesTest extends AbstractUnitTestCase
     public function Nc3()
     {
         $board = new Board();
-        $this->assertEquals(true, $board->play(Convert::toStdObj(Symbol::WHITE, 'Nc3')));
+        $this->assertTrue($board->play(Convert::toStdObj(Symbol::WHITE, 'Nc3')));
     }
 
     /**
@@ -188,7 +188,7 @@ class LegalMovesTest extends AbstractUnitTestCase
     {
         $board = new Board();
         $board->setTurn(Symbol::BLACK);
-        $this->assertEquals(true, $board->play(Convert::toStdObj(Symbol::BLACK, 'Nc6')));
+        $this->assertTrue($board->play(Convert::toStdObj(Symbol::BLACK, 'Nc6')));
     }
 
     /**
@@ -198,7 +198,7 @@ class LegalMovesTest extends AbstractUnitTestCase
     {
         $board = new Board();
         $board->setTurn(Symbol::BLACK);
-        $this->assertEquals(true, $board->play(Convert::toStdObj(Symbol::BLACK, 'Nf6')));
+        $this->assertTrue($board->play(Convert::toStdObj(Symbol::BLACK, 'Nf6')));
     }
 
     /**
@@ -231,7 +231,7 @@ class LegalMovesTest extends AbstractUnitTestCase
 
         $board = new Board($pieces, $castling);
 
-        $this->assertEquals(true, $board->play(Convert::toStdObj(Symbol::WHITE, 'Nxc3')));
+        $this->assertTrue($board->play(Convert::toStdObj(Symbol::WHITE, 'Nxc3')));
     }
 
     /**
@@ -287,7 +287,7 @@ class LegalMovesTest extends AbstractUnitTestCase
         $board = new Board($pieces, $castling);
         $board->setTurn(Symbol::BLACK);
 
-        $this->assertEquals(true, $board->play(Convert::toStdObj(Symbol::BLACK, 'O-O')));
+        $this->assertTrue($board->play(Convert::toStdObj(Symbol::BLACK, 'O-O')));
     }
 
     /**
@@ -325,7 +325,7 @@ class LegalMovesTest extends AbstractUnitTestCase
 
         $board = new Board($pieces, $castling);
 
-        $this->assertEquals(true, $board->play(Convert::toStdObj(Symbol::WHITE, 'Ke4')));
+        $this->assertTrue($board->play(Convert::toStdObj(Symbol::WHITE, 'Ke4')));
     }
 
     /**
@@ -363,7 +363,7 @@ class LegalMovesTest extends AbstractUnitTestCase
 
         $board = new Board($pieces, $castling);
 
-        $this->assertEquals(true, $board->play(Convert::toStdObj(Symbol::WHITE, 'Kg3')));
+        $this->assertTrue($board->play(Convert::toStdObj(Symbol::WHITE, 'Kg3')));
     }
 
     /**
@@ -401,7 +401,7 @@ class LegalMovesTest extends AbstractUnitTestCase
 
         $board = new Board($pieces, $castling);
 
-        $this->assertEquals(true, $board->play(Convert::toStdObj(Symbol::WHITE, 'Kg2')));
+        $this->assertTrue($board->play(Convert::toStdObj(Symbol::WHITE, 'Kg2')));
     }
 
     /**
@@ -439,7 +439,7 @@ class LegalMovesTest extends AbstractUnitTestCase
 
         $board = new Board($pieces, $castling);
 
-        $this->assertEquals(true, $board->play(Convert::toStdObj(Symbol::WHITE, 'Ke2')));
+        $this->assertTrue($board->play(Convert::toStdObj(Symbol::WHITE, 'Ke2')));
     }
 
     /**
@@ -477,7 +477,7 @@ class LegalMovesTest extends AbstractUnitTestCase
 
         $board = new Board($pieces, $castling);
 
-        $this->assertEquals(true, $board->play(Convert::toStdObj(Symbol::WHITE, 'Ke3')));
+        $this->assertTrue($board->play(Convert::toStdObj(Symbol::WHITE, 'Ke3')));
     }
 
     /**
@@ -515,7 +515,7 @@ class LegalMovesTest extends AbstractUnitTestCase
 
         $board = new Board($pieces, $castling);
 
-        $this->assertEquals(true, $board->play(Convert::toStdObj(Symbol::WHITE, 'Kg2')));
+        $this->assertTrue($board->play(Convert::toStdObj(Symbol::WHITE, 'Kg2')));
     }
 
     /**
@@ -553,7 +553,7 @@ class LegalMovesTest extends AbstractUnitTestCase
 
         $board = new Board($pieces, $castling);
 
-        $this->assertEquals(true, $board->play(Convert::toStdObj(Symbol::WHITE, 'Kxh2')));
+        $this->assertTrue($board->play(Convert::toStdObj(Symbol::WHITE, 'Kxh2')));
     }
 
     /**
@@ -591,7 +591,7 @@ class LegalMovesTest extends AbstractUnitTestCase
 
         $board = new Board($pieces, $castling);
 
-        $this->assertEquals(true, $board->play(Convert::toStdObj(Symbol::WHITE, 'Kxf3')));
+        $this->assertTrue($board->play(Convert::toStdObj(Symbol::WHITE, 'Kxf3')));
     }
 
     /**
@@ -608,7 +608,7 @@ class LegalMovesTest extends AbstractUnitTestCase
         $board->play(Convert::toStdObj(Symbol::WHITE, 'Bb5'));
         $board->play(Convert::toStdObj(Symbol::BLACK, 'Nf6'));
 
-        $this->assertEquals(true, $board->play(Convert::toStdObj(Symbol::WHITE, 'O-O')));
+        $this->assertTrue($board->play(Convert::toStdObj(Symbol::WHITE, 'O-O')));
     }
 
     /**
@@ -650,7 +650,7 @@ class LegalMovesTest extends AbstractUnitTestCase
 
         $board = new Board($pieces, $castling);
 
-        $this->assertEquals(true, $board->play(Convert::toStdObj(Symbol::WHITE, 'O-O')));
+        $this->assertTrue($board->play(Convert::toStdObj(Symbol::WHITE, 'O-O')));
     }
 
     /**
@@ -688,8 +688,8 @@ class LegalMovesTest extends AbstractUnitTestCase
 
         $board = new Board($pieces, $castling);
 
-        $this->assertEquals(true, $board->play(Convert::toStdObj(Symbol::WHITE, 'f4')));
-        $this->assertEquals(true, $board->play(Convert::toStdObj(Symbol::BLACK, 'exf3')));
+        $this->assertTrue($board->play(Convert::toStdObj(Symbol::WHITE, 'f4')));
+        $this->assertTrue($board->play(Convert::toStdObj(Symbol::BLACK, 'exf3')));
     }
 
     /**
@@ -728,8 +728,8 @@ class LegalMovesTest extends AbstractUnitTestCase
         $board = new Board($pieces, $castling);
         $board->setTurn(Symbol::BLACK);
 
-        $this->assertEquals(true, $board->play(Convert::toStdObj(Symbol::BLACK, 'f5')));
-        $this->assertEquals(true, $board->play(Convert::toStdObj(Symbol::WHITE, 'exf6')));
+        $this->assertTrue($board->play(Convert::toStdObj(Symbol::BLACK, 'f5')));
+        $this->assertTrue($board->play(Convert::toStdObj(Symbol::WHITE, 'exf6')));
     }
 
     /**
@@ -767,8 +767,8 @@ class LegalMovesTest extends AbstractUnitTestCase
 
         $board = new Board($pieces, $castling);
 
-        $this->assertEquals(true, $board->play(Convert::toStdObj(Symbol::WHITE, 'h4')));
-        $this->assertEquals(true, $board->play(Convert::toStdObj(Symbol::BLACK, 'gxh3')));
+        $this->assertTrue($board->play(Convert::toStdObj(Symbol::WHITE, 'h4')));
+        $this->assertTrue($board->play(Convert::toStdObj(Symbol::BLACK, 'gxh3')));
     }
 
     /**
@@ -806,8 +806,8 @@ class LegalMovesTest extends AbstractUnitTestCase
 
         $board = new Board($pieces, $castling);
 
-        $this->assertEquals(true, $board->play(Convert::toStdObj(Symbol::WHITE, 'g4')));
-        $this->assertEquals(true, $board->play(Convert::toStdObj(Symbol::BLACK, 'hxg3')));
+        $this->assertTrue($board->play(Convert::toStdObj(Symbol::WHITE, 'g4')));
+        $this->assertTrue($board->play(Convert::toStdObj(Symbol::BLACK, 'hxg3')));
     }
 
     /**
@@ -817,30 +817,30 @@ class LegalMovesTest extends AbstractUnitTestCase
     {
         $board = new Board();
 
-        $this->assertEquals(true, $board->play(Convert::toStdObj(Symbol::WHITE, 'e4')));
-        $this->assertEquals(true, $board->play(Convert::toStdObj(Symbol::BLACK, 'e6')));
-        $this->assertEquals(true, $board->play(Convert::toStdObj(Symbol::WHITE, 'd4')));
-        $this->assertEquals(true, $board->play(Convert::toStdObj(Symbol::BLACK, 'd5')));
-        $this->assertEquals(true, $board->play(Convert::toStdObj(Symbol::WHITE, 'Nc3')));
-        $this->assertEquals(true, $board->play(Convert::toStdObj(Symbol::BLACK, 'Bb4')));
-        $this->assertEquals(true, $board->play(Convert::toStdObj(Symbol::WHITE, 'e5')));
-        $this->assertEquals(true, $board->play(Convert::toStdObj(Symbol::BLACK, 'c5')));
-        $this->assertEquals(true, $board->play(Convert::toStdObj(Symbol::WHITE, 'Qg4')));
-        $this->assertEquals(true, $board->play(Convert::toStdObj(Symbol::BLACK, 'Ne7')));
-        $this->assertEquals(true, $board->play(Convert::toStdObj(Symbol::WHITE, 'Nf3')));
-        $this->assertEquals(true, $board->play(Convert::toStdObj(Symbol::BLACK, 'Nbc6')));
-        $this->assertEquals(true, $board->play(Convert::toStdObj(Symbol::WHITE, 'a3')));
-        $this->assertEquals(true, $board->play(Convert::toStdObj(Symbol::BLACK, 'Bxc3+')));
-        $this->assertEquals(true, $board->play(Convert::toStdObj(Symbol::WHITE, 'bxc3')));
-        $this->assertEquals(true, $board->play(Convert::toStdObj(Symbol::BLACK, 'Qc7')));
-        $this->assertEquals(true, $board->play(Convert::toStdObj(Symbol::WHITE, 'Rb1')));
-        $this->assertEquals(true, $board->play(Convert::toStdObj(Symbol::BLACK, 'O-O')));
-        $this->assertEquals(true, $board->play(Convert::toStdObj(Symbol::WHITE, 'Bd3')));
-        $this->assertEquals(true, $board->play(Convert::toStdObj(Symbol::BLACK, 'f5')));
+        $this->assertTrue($board->play(Convert::toStdObj(Symbol::WHITE, 'e4')));
+        $this->assertTrue($board->play(Convert::toStdObj(Symbol::BLACK, 'e6')));
+        $this->assertTrue($board->play(Convert::toStdObj(Symbol::WHITE, 'd4')));
+        $this->assertTrue($board->play(Convert::toStdObj(Symbol::BLACK, 'd5')));
+        $this->assertTrue($board->play(Convert::toStdObj(Symbol::WHITE, 'Nc3')));
+        $this->assertTrue($board->play(Convert::toStdObj(Symbol::BLACK, 'Bb4')));
+        $this->assertTrue($board->play(Convert::toStdObj(Symbol::WHITE, 'e5')));
+        $this->assertTrue($board->play(Convert::toStdObj(Symbol::BLACK, 'c5')));
+        $this->assertTrue($board->play(Convert::toStdObj(Symbol::WHITE, 'Qg4')));
+        $this->assertTrue($board->play(Convert::toStdObj(Symbol::BLACK, 'Ne7')));
+        $this->assertTrue($board->play(Convert::toStdObj(Symbol::WHITE, 'Nf3')));
+        $this->assertTrue($board->play(Convert::toStdObj(Symbol::BLACK, 'Nbc6')));
+        $this->assertTrue($board->play(Convert::toStdObj(Symbol::WHITE, 'a3')));
+        $this->assertTrue($board->play(Convert::toStdObj(Symbol::BLACK, 'Bxc3+')));
+        $this->assertTrue($board->play(Convert::toStdObj(Symbol::WHITE, 'bxc3')));
+        $this->assertTrue($board->play(Convert::toStdObj(Symbol::BLACK, 'Qc7')));
+        $this->assertTrue($board->play(Convert::toStdObj(Symbol::WHITE, 'Rb1')));
+        $this->assertTrue($board->play(Convert::toStdObj(Symbol::BLACK, 'O-O')));
+        $this->assertTrue($board->play(Convert::toStdObj(Symbol::WHITE, 'Bd3')));
+        $this->assertTrue($board->play(Convert::toStdObj(Symbol::BLACK, 'f5')));
         $pawn_e5 = $board->getPieceByPosition('e5');
         $pawn_e5->getLegalMoves(); // this creates the enPassantSquare property in the pawn's position object
-        $this->assertEquals('f5', $pawn_e5->getEnPassantSquare());
-        $this->assertEquals(true, $board->play(Convert::toStdObj(Symbol::WHITE, 'exf6')));
+        $this->assertSame('f5', $pawn_e5->getEnPassantSquare());
+        $this->assertTrue($board->play(Convert::toStdObj(Symbol::WHITE, 'exf6')));
     }
 
     /**
@@ -877,8 +877,8 @@ class LegalMovesTest extends AbstractUnitTestCase
         $board = new Board($pieces, $castling);
         $board->setTurn(Symbol::BLACK);
 
-        $this->assertEquals(true, $board->play(Convert::toStdObj(Symbol::BLACK, 'b5')));
-        $this->assertEquals(true, $board->play(Convert::toStdObj(Symbol::WHITE, 'cxb6')));
+        $this->assertTrue($board->play(Convert::toStdObj(Symbol::BLACK, 'b5')));
+        $this->assertTrue($board->play(Convert::toStdObj(Symbol::WHITE, 'cxb6')));
     }
 
     /**
@@ -913,7 +913,7 @@ class LegalMovesTest extends AbstractUnitTestCase
 
         $board = new Board($pieces, $castling);
 
-        $this->assertEquals(true, $board->play(Convert::toStdObj(Symbol::WHITE, 'h8=Q')));
+        $this->assertTrue($board->play(Convert::toStdObj(Symbol::WHITE, 'h8=Q')));
     }
 
     /**
@@ -952,20 +952,20 @@ class LegalMovesTest extends AbstractUnitTestCase
 
         $board = new Board($pieces, $castling);
 
-        $this->assertEquals(true, $board->play(Convert::toStdObj(Symbol::WHITE, 'Ra8+')));
-        $this->assertEquals(true, $board->isCheck());
-        $this->assertEquals(false, $board->play(Convert::toStdObj(Symbol::BLACK, 'Kd8')));
-        $this->assertEquals(true, $board->isCheck());
-        $this->assertEquals(false, $board->play(Convert::toStdObj(Symbol::BLACK, 'Kf8')));
-        $this->assertEquals(true, $board->isCheck());
-        $this->assertEquals(true, $board->play(Convert::toStdObj(Symbol::BLACK, 'Ke7')));
-        $this->assertEquals(false, $board->isCheck());
-        $this->assertEquals(true, $board->play(Convert::toStdObj(Symbol::WHITE, 'h3')));
-        $this->assertEquals(false, $board->isCheck());
-        $this->assertEquals(false, $board->play(Convert::toStdObj(Symbol::BLACK, 'Nc2')));
-        $this->assertEquals(false, $board->isCheck());
-        $this->assertEquals(true, $board->play(Convert::toStdObj(Symbol::BLACK, 'Rxg2+')));
-        $this->assertEquals(true, $board->isCheck());
+        $this->assertTrue($board->play(Convert::toStdObj(Symbol::WHITE, 'Ra8+')));
+        $this->assertTrue($board->isCheck());
+        $this->assertFalse($board->play(Convert::toStdObj(Symbol::BLACK, 'Kd8')));
+        $this->assertTrue($board->isCheck());
+        $this->assertFalse($board->play(Convert::toStdObj(Symbol::BLACK, 'Kf8')));
+        $this->assertTrue($board->isCheck());
+        $this->assertTrue($board->play(Convert::toStdObj(Symbol::BLACK, 'Ke7')));
+        $this->assertFalse($board->isCheck());
+        $this->assertTrue($board->play(Convert::toStdObj(Symbol::WHITE, 'h3')));
+        $this->assertFalse($board->isCheck());
+        $this->assertFalse($board->play(Convert::toStdObj(Symbol::BLACK, 'Nc2')));
+        $this->assertFalse($board->isCheck());
+        $this->assertTrue($board->play(Convert::toStdObj(Symbol::BLACK, 'Rxg2+')));
+        $this->assertTrue($board->isCheck());
     }
 
     /**
@@ -1000,33 +1000,33 @@ class LegalMovesTest extends AbstractUnitTestCase
 
         $board = new Board($pieces, $castling);
 
-        $this->assertEquals(true, $board->play(Convert::toStdObj(Symbol::WHITE, 'd6+')));
-        $this->assertEquals(true, $board->isCheck());
-        $this->assertEquals(false, $board->isMate());
-        $this->assertEquals(false, $board->play(Convert::toStdObj(Symbol::BLACK, 'Kd7')));
-        $this->assertEquals(true, $board->isCheck());
-        $this->assertEquals(false, $board->isMate());
-        $this->assertEquals(false, $board->play(Convert::toStdObj(Symbol::BLACK, 'Ke6')));
-        $this->assertEquals(true, $board->isCheck());
-        $this->assertEquals(false, $board->isMate());
-        $this->assertEquals(true, $board->play(Convert::toStdObj(Symbol::BLACK, 'Kxd6')));
-        $this->assertEquals(false, $board->isCheck());
-        $this->assertEquals(false, $board->isMate());
-        $this->assertEquals(true, $board->play(Convert::toStdObj(Symbol::WHITE, 'Re8')));
-        $this->assertEquals(false, $board->isCheck());
-        $this->assertEquals(false, $board->isMate());
-        $this->assertEquals(true, $board->play(Convert::toStdObj(Symbol::BLACK, 'Kc7')));
-        $this->assertEquals(false, $board->isCheck());
-        $this->assertEquals(false, $board->isMate());
-        $this->assertEquals(true, $board->play(Convert::toStdObj(Symbol::WHITE, 'Re7+')));
-        $this->assertEquals(true, $board->isCheck());
-        $this->assertEquals(false, $board->isMate());
-        $this->assertEquals(true, $board->play(Convert::toStdObj(Symbol::BLACK, 'Kd8')));
-        $this->assertEquals(false, $board->isCheck());
-        $this->assertEquals(false, $board->isMate());
-        $this->assertEquals(true, $board->play(Convert::toStdObj(Symbol::WHITE, 'Qd7#')));
-        $this->assertEquals(true, $board->isCheck());
-        $this->assertEquals(true, $board->isMate());
+        $this->assertTrue($board->play(Convert::toStdObj(Symbol::WHITE, 'd6+')));
+        $this->assertTrue($board->isCheck());
+        $this->assertFalse($board->isMate());
+        $this->assertFalse($board->play(Convert::toStdObj(Symbol::BLACK, 'Kd7')));
+        $this->assertTrue($board->isCheck());
+        $this->assertFalse($board->isMate());
+        $this->assertFalse($board->play(Convert::toStdObj(Symbol::BLACK, 'Ke6')));
+        $this->assertTrue($board->isCheck());
+        $this->assertFalse($board->isMate());
+        $this->assertTrue($board->play(Convert::toStdObj(Symbol::BLACK, 'Kxd6')));
+        $this->assertFalse($board->isCheck());
+        $this->assertFalse($board->isMate());
+        $this->assertTrue($board->play(Convert::toStdObj(Symbol::WHITE, 'Re8')));
+        $this->assertFalse($board->isCheck());
+        $this->assertFalse($board->isMate());
+        $this->assertTrue($board->play(Convert::toStdObj(Symbol::BLACK, 'Kc7')));
+        $this->assertFalse($board->isCheck());
+        $this->assertFalse($board->isMate());
+        $this->assertTrue($board->play(Convert::toStdObj(Symbol::WHITE, 'Re7+')));
+        $this->assertTrue($board->isCheck());
+        $this->assertFalse($board->isMate());
+        $this->assertTrue($board->play(Convert::toStdObj(Symbol::BLACK, 'Kd8')));
+        $this->assertFalse($board->isCheck());
+        $this->assertFalse($board->isMate());
+        $this->assertTrue($board->play(Convert::toStdObj(Symbol::WHITE, 'Qd7#')));
+        $this->assertTrue($board->isCheck());
+        $this->assertTrue($board->isMate());
     }
 
     /**
@@ -1035,13 +1035,13 @@ class LegalMovesTest extends AbstractUnitTestCase
     public function captures()
     {
         $board = new Board();
-        $this->assertEquals(true, $board->play(Convert::toStdObj(Symbol::WHITE, 'e4')));
-        $this->assertEquals(true, $board->play(Convert::toStdObj(Symbol::BLACK, 'e5')));
-        $this->assertEquals(true, $board->play(Convert::toStdObj(Symbol::WHITE, 'd4')));
-        $this->assertEquals(true, $board->play(Convert::toStdObj(Symbol::BLACK, 'Bb4')));
-        $this->assertEquals(true, $board->play(Convert::toStdObj(Symbol::WHITE, 'c3')));
-        $this->assertEquals(true, $board->play(Convert::toStdObj(Symbol::BLACK, 'Bxc3')));
-        $this->assertEquals(true, $board->play(Convert::toStdObj(Symbol::WHITE, 'bxc3')));
+        $this->assertTrue($board->play(Convert::toStdObj(Symbol::WHITE, 'e4')));
+        $this->assertTrue($board->play(Convert::toStdObj(Symbol::BLACK, 'e5')));
+        $this->assertTrue($board->play(Convert::toStdObj(Symbol::WHITE, 'd4')));
+        $this->assertTrue($board->play(Convert::toStdObj(Symbol::BLACK, 'Bb4')));
+        $this->assertTrue($board->play(Convert::toStdObj(Symbol::WHITE, 'c3')));
+        $this->assertTrue($board->play(Convert::toStdObj(Symbol::BLACK, 'Bxc3')));
+        $this->assertTrue($board->play(Convert::toStdObj(Symbol::WHITE, 'bxc3')));
     }
 
     /**
@@ -1050,14 +1050,14 @@ class LegalMovesTest extends AbstractUnitTestCase
     public function e4_e5_Nf3_Nc6_Be2_Be7()
     {
         $board = new Board();
-        $this->assertEquals(true, $board->play(Convert::toStdObj(Symbol::WHITE, 'e4')));
-        $this->assertEquals(true, $board->play(Convert::toStdObj(Symbol::BLACK, 'e5')));
-        $this->assertEquals(true, $board->play(Convert::toStdObj(Symbol::WHITE, 'Nf3')));
-        $this->assertEquals(true, $board->play(Convert::toStdObj(Symbol::BLACK, 'Nc6')));
-        $this->assertEquals(true, $board->play(Convert::toStdObj(Symbol::WHITE, 'Be2')));
-        $this->assertEquals(true, $board->play(Convert::toStdObj(Symbol::BLACK, 'Be7')));
+        $this->assertTrue($board->play(Convert::toStdObj(Symbol::WHITE, 'e4')));
+        $this->assertTrue($board->play(Convert::toStdObj(Symbol::BLACK, 'e5')));
+        $this->assertTrue($board->play(Convert::toStdObj(Symbol::WHITE, 'Nf3')));
+        $this->assertTrue($board->play(Convert::toStdObj(Symbol::BLACK, 'Nc6')));
+        $this->assertTrue($board->play(Convert::toStdObj(Symbol::WHITE, 'Be2')));
+        $this->assertTrue($board->play(Convert::toStdObj(Symbol::BLACK, 'Be7')));
         // short castling, O-O
-        $this->assertEquals(true, $board->play(Convert::toStdObj(Symbol::WHITE, 'Kg1')));
+        $this->assertTrue($board->play(Convert::toStdObj(Symbol::WHITE, 'Kg1')));
     }
 
     /**
@@ -1066,11 +1066,11 @@ class LegalMovesTest extends AbstractUnitTestCase
     public function Nf3_Nf6_d3_d6_Nfd2()
     {
         $board = new Board();
-        $this->assertEquals(true, $board->play(Convert::toStdObj(Symbol::WHITE, 'Nf3')));
-        $this->assertEquals(true, $board->play(Convert::toStdObj(Symbol::BLACK, 'Nf6')));
-        $this->assertEquals(true, $board->play(Convert::toStdObj(Symbol::WHITE, 'd3')));
-        $this->assertEquals(true, $board->play(Convert::toStdObj(Symbol::BLACK, 'd6')));
-        $this->assertEquals(true, $board->play(Convert::toStdObj(Symbol::WHITE, 'Nfd2')));
+        $this->assertTrue($board->play(Convert::toStdObj(Symbol::WHITE, 'Nf3')));
+        $this->assertTrue($board->play(Convert::toStdObj(Symbol::BLACK, 'Nf6')));
+        $this->assertTrue($board->play(Convert::toStdObj(Symbol::WHITE, 'd3')));
+        $this->assertTrue($board->play(Convert::toStdObj(Symbol::BLACK, 'd6')));
+        $this->assertTrue($board->play(Convert::toStdObj(Symbol::WHITE, 'Nfd2')));
     }
 
     /**
@@ -1079,11 +1079,11 @@ class LegalMovesTest extends AbstractUnitTestCase
     public function Nf3_Nf6_d3_d6_Nf3d2()
     {
         $board = new Board();
-        $this->assertEquals(true, $board->play(Convert::toStdObj(Symbol::WHITE, 'Nf3')));
-        $this->assertEquals(true, $board->play(Convert::toStdObj(Symbol::BLACK, 'Nf6')));
-        $this->assertEquals(true, $board->play(Convert::toStdObj(Symbol::WHITE, 'd3')));
-        $this->assertEquals(true, $board->play(Convert::toStdObj(Symbol::BLACK, 'd6')));
-        $this->assertEquals(true, $board->play(Convert::toStdObj(Symbol::WHITE, 'Nf3d2')));
+        $this->assertTrue($board->play(Convert::toStdObj(Symbol::WHITE, 'Nf3')));
+        $this->assertTrue($board->play(Convert::toStdObj(Symbol::BLACK, 'Nf6')));
+        $this->assertTrue($board->play(Convert::toStdObj(Symbol::WHITE, 'd3')));
+        $this->assertTrue($board->play(Convert::toStdObj(Symbol::BLACK, 'd6')));
+        $this->assertTrue($board->play(Convert::toStdObj(Symbol::WHITE, 'Nf3d2')));
     }
 
     /**
@@ -1092,11 +1092,11 @@ class LegalMovesTest extends AbstractUnitTestCase
     public function e4_d5_exd5_e5_dxe6()
     {
         $board = new Board();
-        $this->assertEquals(true, $board->play(Convert::toStdObj(Symbol::WHITE, 'e4')));
-        $this->assertEquals(true, $board->play(Convert::toStdObj(Symbol::BLACK, 'd5')));
-        $this->assertEquals(true, $board->play(Convert::toStdObj(Symbol::WHITE, 'exd5')));
-        $this->assertEquals(true, $board->play(Convert::toStdObj(Symbol::BLACK, 'e5')));
-        $this->assertEquals(true, $board->play(Convert::toStdObj(Symbol::WHITE, 'dxe6')));
+        $this->assertTrue($board->play(Convert::toStdObj(Symbol::WHITE, 'e4')));
+        $this->assertTrue($board->play(Convert::toStdObj(Symbol::BLACK, 'd5')));
+        $this->assertTrue($board->play(Convert::toStdObj(Symbol::WHITE, 'exd5')));
+        $this->assertTrue($board->play(Convert::toStdObj(Symbol::BLACK, 'e5')));
+        $this->assertTrue($board->play(Convert::toStdObj(Symbol::WHITE, 'dxe6')));
     }
 
     /**
@@ -1105,12 +1105,12 @@ class LegalMovesTest extends AbstractUnitTestCase
     public function e4_d5_exd5_e5_then_get_piece()
     {
         $board = new Board();
-        $this->assertEquals(true, $board->play(Convert::toStdObj(Symbol::WHITE, 'e4')));
-        $this->assertEquals(true, $board->play(Convert::toStdObj(Symbol::BLACK, 'd5')));
-        $this->assertEquals(true, $board->play(Convert::toStdObj(Symbol::WHITE, 'exd5')));
-        $this->assertEquals(true, $board->play(Convert::toStdObj(Symbol::BLACK, 'e5')));
+        $this->assertTrue($board->play(Convert::toStdObj(Symbol::WHITE, 'e4')));
+        $this->assertTrue($board->play(Convert::toStdObj(Symbol::BLACK, 'd5')));
+        $this->assertTrue($board->play(Convert::toStdObj(Symbol::WHITE, 'exd5')));
+        $this->assertTrue($board->play(Convert::toStdObj(Symbol::BLACK, 'e5')));
 
-        $this->assertEquals('P', $board->getPieceByPosition('d5')->getIdentity());
+        $this->assertSame('P', $board->getPieceByPosition('d5')->getIdentity());
     }
 
     /**
@@ -1119,16 +1119,16 @@ class LegalMovesTest extends AbstractUnitTestCase
     public function e4_c5_Nf3_d6_d4_cxd4_Nxd4_Nf6_Nc3_Nc6()
     {
         $board = new Board();
-        $this->assertEquals(true, $board->play(Convert::toStdObj(Symbol::WHITE, 'e4')));
-        $this->assertEquals(true, $board->play(Convert::toStdObj(Symbol::BLACK, 'c5')));
-        $this->assertEquals(true, $board->play(Convert::toStdObj(Symbol::WHITE, 'Nf3')));
-        $this->assertEquals(true, $board->play(Convert::toStdObj(Symbol::BLACK, 'd6')));
-        $this->assertEquals(true, $board->play(Convert::toStdObj(Symbol::WHITE, 'd4')));
-        $this->assertEquals(true, $board->play(Convert::toStdObj(Symbol::BLACK, 'cxd4')));
-        $this->assertEquals(true, $board->play(Convert::toStdObj(Symbol::WHITE, 'Nxd4')));
-        $this->assertEquals(true, $board->play(Convert::toStdObj(Symbol::BLACK, 'Nf6')));
-        $this->assertEquals(true, $board->play(Convert::toStdObj(Symbol::WHITE, 'Nc3')));
-        $this->assertEquals(true, $board->play(Convert::toStdObj(Symbol::BLACK, 'Nc6')));
+        $this->assertTrue($board->play(Convert::toStdObj(Symbol::WHITE, 'e4')));
+        $this->assertTrue($board->play(Convert::toStdObj(Symbol::BLACK, 'c5')));
+        $this->assertTrue($board->play(Convert::toStdObj(Symbol::WHITE, 'Nf3')));
+        $this->assertTrue($board->play(Convert::toStdObj(Symbol::BLACK, 'd6')));
+        $this->assertTrue($board->play(Convert::toStdObj(Symbol::WHITE, 'd4')));
+        $this->assertTrue($board->play(Convert::toStdObj(Symbol::BLACK, 'cxd4')));
+        $this->assertTrue($board->play(Convert::toStdObj(Symbol::WHITE, 'Nxd4')));
+        $this->assertTrue($board->play(Convert::toStdObj(Symbol::BLACK, 'Nf6')));
+        $this->assertTrue($board->play(Convert::toStdObj(Symbol::WHITE, 'Nc3')));
+        $this->assertTrue($board->play(Convert::toStdObj(Symbol::BLACK, 'Nc6')));
     }
 
     /**
@@ -1137,14 +1137,14 @@ class LegalMovesTest extends AbstractUnitTestCase
     public function e4_c5_Nf3_d6_d4_cxd4_Nxd4_Nf6_then_get_piece()
     {
         $board = new Board();
-        $this->assertEquals(true, $board->play(Convert::toStdObj(Symbol::WHITE, 'e4')));
-        $this->assertEquals(true, $board->play(Convert::toStdObj(Symbol::BLACK, 'c5')));
-        $this->assertEquals(true, $board->play(Convert::toStdObj(Symbol::WHITE, 'Nf3')));
-        $this->assertEquals(true, $board->play(Convert::toStdObj(Symbol::BLACK, 'd6')));
-        $this->assertEquals(true, $board->play(Convert::toStdObj(Symbol::WHITE, 'd4')));
-        $this->assertEquals(true, $board->play(Convert::toStdObj(Symbol::BLACK, 'cxd4')));
-        $this->assertEquals(true, $board->play(Convert::toStdObj(Symbol::WHITE, 'Nxd4')));
-        $this->assertEquals(true, $board->play(Convert::toStdObj(Symbol::BLACK, 'Nf6')));
+        $this->assertTrue($board->play(Convert::toStdObj(Symbol::WHITE, 'e4')));
+        $this->assertTrue($board->play(Convert::toStdObj(Symbol::BLACK, 'c5')));
+        $this->assertTrue($board->play(Convert::toStdObj(Symbol::WHITE, 'Nf3')));
+        $this->assertTrue($board->play(Convert::toStdObj(Symbol::BLACK, 'd6')));
+        $this->assertTrue($board->play(Convert::toStdObj(Symbol::WHITE, 'd4')));
+        $this->assertTrue($board->play(Convert::toStdObj(Symbol::BLACK, 'cxd4')));
+        $this->assertTrue($board->play(Convert::toStdObj(Symbol::WHITE, 'Nxd4')));
+        $this->assertTrue($board->play(Convert::toStdObj(Symbol::BLACK, 'Nf6')));
 
         $this->assertNotEmpty($board->getPieceByPosition('b1')->getLegalMoves());
     }

--- a/tests/unit/Board/PossibleMovesTest.php
+++ b/tests/unit/Board/PossibleMovesTest.php
@@ -40,7 +40,7 @@ class PossibleMovesTest extends AbstractUnitTestCase
             'h4',
         ];
 
-        $this->assertEquals($expected, $possibleMoves);
+        $this->assertSame($expected, $possibleMoves);
     }
 
     /**
@@ -75,7 +75,7 @@ class PossibleMovesTest extends AbstractUnitTestCase
             'h5',
         ];
 
-        $this->assertEquals($expected, $possibleMoves);
+        $this->assertSame($expected, $possibleMoves);
     }
 
     /**
@@ -123,6 +123,6 @@ class PossibleMovesTest extends AbstractUnitTestCase
             'Bf1',
         ];
 
-        $this->assertEquals($expected, $possibleMoves);
+        $this->assertSame($expected, $possibleMoves);
     }
 }

--- a/tests/unit/Board/StatusTest.php
+++ b/tests/unit/Board/StatusTest.php
@@ -103,7 +103,7 @@ class StatusTest extends AbstractUnitTestCase
 
         $expected = '1.e4 e5 2.Nf3 Nc6 3.Bb5 a6 4.Bxc6 dxc6 5.d4 exd4 6.Qxd4 Qxd4 7.Nxd4';
 
-        $this->assertEquals($expected, $board->getMovetext());
+        $this->assertSame($expected, $board->getMovetext());
     }
 
     /**
@@ -293,7 +293,7 @@ class StatusTest extends AbstractUnitTestCase
 
         $expected = [ 'e1', 'e2', 'g2' ];
 
-        $this->assertEquals($expected, $king->getLegalMoves());
+        $this->assertSame($expected, $king->getLegalMoves());
     }
 
     /**
@@ -303,8 +303,8 @@ class StatusTest extends AbstractUnitTestCase
     {
         $board = (new BenkoGambit(new Board()))->play();
 
-        $this->assertEquals(14, count($board->getPiecesByColor(Symbol::WHITE)));
-        $this->assertEquals(13, count($board->getPiecesByColor(Symbol::BLACK)));
+        $this->assertSame(14, count($board->getPiecesByColor(Symbol::WHITE)));
+        $this->assertSame(13, count($board->getPiecesByColor(Symbol::BLACK)));
     }
 
     /**
@@ -318,7 +318,7 @@ class StatusTest extends AbstractUnitTestCase
 
         $expected = [ 'e1', 'c2', 'b3' ];
 
-        $this->assertEquals($expected, $queen->getLegalMoves());
+        $this->assertSame($expected, $queen->getLegalMoves());
     }
 
     /**
@@ -328,8 +328,8 @@ class StatusTest extends AbstractUnitTestCase
     {
         $board = (new BenoniFianchettoVariation(new Board()))->play();
 
-        $this->assertEquals(15, count($board->getPiecesByColor(Symbol::WHITE)));
-        $this->assertEquals(15, count($board->getPiecesByColor(Symbol::BLACK)));
+        $this->assertSame(15, count($board->getPiecesByColor(Symbol::WHITE)));
+        $this->assertSame(15, count($board->getPiecesByColor(Symbol::BLACK)));
     }
 
     /**
@@ -339,8 +339,8 @@ class StatusTest extends AbstractUnitTestCase
     {
         $board = (new OpenSicilian(new Board()))->play();
 
-        $this->assertEquals(15, count($board->getPiecesByColor(Symbol::WHITE)));
-        $this->assertEquals(15, count($board->getPiecesByColor(Symbol::BLACK)));
+        $this->assertSame(15, count($board->getPiecesByColor(Symbol::WHITE)));
+        $this->assertSame(15, count($board->getPiecesByColor(Symbol::BLACK)));
     }
 
     /**

--- a/tests/unit/CastlingTest.php
+++ b/tests/unit/CastlingTest.php
@@ -22,13 +22,13 @@ class CastlingTest extends AbstractUnitTestCase
     {
         $rule = CastlingRule::color(Symbol::WHITE);
 
-        $this->assertEquals($rule[Symbol::KING][Symbol::CASTLING_LONG]['squares']['b'], 'b1');
-        $this->assertEquals($rule[Symbol::KING][Symbol::CASTLING_LONG]['squares']['c'], 'c1');
-        $this->assertEquals($rule[Symbol::KING][Symbol::CASTLING_LONG]['squares']['d'], 'd1');
-        $this->assertEquals($rule[Symbol::KING][Symbol::CASTLING_LONG]['position']['current'], 'e1');
-        $this->assertEquals($rule[Symbol::KING][Symbol::CASTLING_LONG]['position']['next'], 'c1');
-        $this->assertEquals($rule[Symbol::ROOK][Symbol::CASTLING_LONG]['position']['current'], 'a1');
-        $this->assertEquals($rule[Symbol::ROOK][Symbol::CASTLING_LONG]['position']['next'], 'd1');
+        $this->assertSame($rule[Symbol::KING][Symbol::CASTLING_LONG]['squares']['b'], 'b1');
+        $this->assertSame($rule[Symbol::KING][Symbol::CASTLING_LONG]['squares']['c'], 'c1');
+        $this->assertSame($rule[Symbol::KING][Symbol::CASTLING_LONG]['squares']['d'], 'd1');
+        $this->assertSame($rule[Symbol::KING][Symbol::CASTLING_LONG]['position']['current'], 'e1');
+        $this->assertSame($rule[Symbol::KING][Symbol::CASTLING_LONG]['position']['next'], 'c1');
+        $this->assertSame($rule[Symbol::ROOK][Symbol::CASTLING_LONG]['position']['current'], 'a1');
+        $this->assertSame($rule[Symbol::ROOK][Symbol::CASTLING_LONG]['position']['next'], 'd1');
     }
 
     /**
@@ -38,13 +38,13 @@ class CastlingTest extends AbstractUnitTestCase
     {
         $rule = CastlingRule::color(Symbol::BLACK);
 
-        $this->assertEquals($rule[Symbol::KING][Symbol::CASTLING_LONG]['squares']['b'], 'b8');
-        $this->assertEquals($rule[Symbol::KING][Symbol::CASTLING_LONG]['squares']['c'], 'c8');
-        $this->assertEquals($rule[Symbol::KING][Symbol::CASTLING_LONG]['squares']['d'], 'd8');
-        $this->assertEquals($rule[Symbol::KING][Symbol::CASTLING_LONG]['position']['current'], 'e8');
-        $this->assertEquals($rule[Symbol::KING][Symbol::CASTLING_LONG]['position']['next'], 'c8');
-        $this->assertEquals($rule[Symbol::ROOK][Symbol::CASTLING_LONG]['position']['current'], 'a8');
-        $this->assertEquals($rule[Symbol::ROOK][Symbol::CASTLING_LONG]['position']['next'], 'd8');
+        $this->assertSame($rule[Symbol::KING][Symbol::CASTLING_LONG]['squares']['b'], 'b8');
+        $this->assertSame($rule[Symbol::KING][Symbol::CASTLING_LONG]['squares']['c'], 'c8');
+        $this->assertSame($rule[Symbol::KING][Symbol::CASTLING_LONG]['squares']['d'], 'd8');
+        $this->assertSame($rule[Symbol::KING][Symbol::CASTLING_LONG]['position']['current'], 'e8');
+        $this->assertSame($rule[Symbol::KING][Symbol::CASTLING_LONG]['position']['next'], 'c8');
+        $this->assertSame($rule[Symbol::ROOK][Symbol::CASTLING_LONG]['position']['current'], 'a8');
+        $this->assertSame($rule[Symbol::ROOK][Symbol::CASTLING_LONG]['position']['next'], 'd8');
     }
 
     /**
@@ -54,12 +54,12 @@ class CastlingTest extends AbstractUnitTestCase
     {
         $rule = CastlingRule::color(Symbol::WHITE);
 
-        $this->assertEquals($rule[Symbol::KING][Symbol::CASTLING_SHORT]['squares']['f'], 'f1');
-        $this->assertEquals($rule[Symbol::KING][Symbol::CASTLING_SHORT]['squares']['g'], 'g1');
-        $this->assertEquals($rule[Symbol::KING][Symbol::CASTLING_SHORT]['position']['current'], 'e1');
-        $this->assertEquals($rule[Symbol::KING][Symbol::CASTLING_SHORT]['position']['next'], 'g1');
-        $this->assertEquals($rule[Symbol::ROOK][Symbol::CASTLING_SHORT]['position']['current'], 'h1');
-        $this->assertEquals($rule[Symbol::ROOK][Symbol::CASTLING_SHORT]['position']['next'], 'f1');
+        $this->assertSame($rule[Symbol::KING][Symbol::CASTLING_SHORT]['squares']['f'], 'f1');
+        $this->assertSame($rule[Symbol::KING][Symbol::CASTLING_SHORT]['squares']['g'], 'g1');
+        $this->assertSame($rule[Symbol::KING][Symbol::CASTLING_SHORT]['position']['current'], 'e1');
+        $this->assertSame($rule[Symbol::KING][Symbol::CASTLING_SHORT]['position']['next'], 'g1');
+        $this->assertSame($rule[Symbol::ROOK][Symbol::CASTLING_SHORT]['position']['current'], 'h1');
+        $this->assertSame($rule[Symbol::ROOK][Symbol::CASTLING_SHORT]['position']['next'], 'f1');
     }
 
     /**
@@ -69,12 +69,12 @@ class CastlingTest extends AbstractUnitTestCase
     {
         $rule = CastlingRule::color(Symbol::BLACK);
 
-        $this->assertEquals($rule[Symbol::KING][Symbol::CASTLING_SHORT]['squares']['f'], 'f8');
-        $this->assertEquals($rule[Symbol::KING][Symbol::CASTLING_SHORT]['squares']['g'], 'g8');
-        $this->assertEquals($rule[Symbol::KING][Symbol::CASTLING_SHORT]['position']['current'], 'e8');
-        $this->assertEquals($rule[Symbol::KING][Symbol::CASTLING_SHORT]['position']['next'], 'g8');
-        $this->assertEquals($rule[Symbol::ROOK][Symbol::CASTLING_SHORT]['position']['current'], 'h8');
-        $this->assertEquals($rule[Symbol::ROOK][Symbol::CASTLING_SHORT]['position']['next'], 'f8');
+        $this->assertSame($rule[Symbol::KING][Symbol::CASTLING_SHORT]['squares']['f'], 'f8');
+        $this->assertSame($rule[Symbol::KING][Symbol::CASTLING_SHORT]['squares']['g'], 'g8');
+        $this->assertSame($rule[Symbol::KING][Symbol::CASTLING_SHORT]['position']['current'], 'e8');
+        $this->assertSame($rule[Symbol::KING][Symbol::CASTLING_SHORT]['position']['next'], 'g8');
+        $this->assertSame($rule[Symbol::ROOK][Symbol::CASTLING_SHORT]['position']['current'], 'h8');
+        $this->assertSame($rule[Symbol::ROOK][Symbol::CASTLING_SHORT]['position']['next'], 'f8');
     }
 
     /**
@@ -97,6 +97,6 @@ class CastlingTest extends AbstractUnitTestCase
             ],
         ];
 
-        $this->assertEquals($expected, $board->getCastling());
+        $this->assertSame($expected, $board->getCastling());
     }
 }

--- a/tests/unit/Combinatorics/PermutationWithRepetitionTest.php
+++ b/tests/unit/Combinatorics/PermutationWithRepetitionTest.php
@@ -26,6 +26,6 @@ class PermutationWithRepetitionTest extends AbstractUnitTestCase
             ['c', 'c'],
         ];
 
-        $this->assertEquals($expected, $set);
+        $this->assertSame($expected, $set);
     }
 }

--- a/tests/unit/Combinatorics/RestrictedPermutationWithRepetitionTest.php
+++ b/tests/unit/Combinatorics/RestrictedPermutationWithRepetitionTest.php
@@ -24,7 +24,7 @@ class RestrictedPermutationWithRepetitionTest extends AbstractUnitTestCase
 
         $expected = 588;
 
-        $this->assertEquals($expected, $count);
+        $this->assertSame($expected, $count);
     }
 
     /**
@@ -37,7 +37,7 @@ class RestrictedPermutationWithRepetitionTest extends AbstractUnitTestCase
 
         $expected = [ 34, 13, 13, 8, 8, 8, 8, 8 ];
 
-        $this->assertEquals($expected, $first);
+        $this->assertSame($expected, $first);
     }
 
     /**
@@ -50,7 +50,7 @@ class RestrictedPermutationWithRepetitionTest extends AbstractUnitTestCase
 
         $expected = [ 8, 8, 8, 8, 8, 13, 13, 34 ];
 
-        $this->assertEquals($expected, $last);
+        $this->assertSame($expected, $last);
     }
 
     /**
@@ -69,7 +69,7 @@ class RestrictedPermutationWithRepetitionTest extends AbstractUnitTestCase
             [ 13, 34, 8, 13, 8, 8, 8, 8 ],
         ];
 
-        $this->assertEquals($expected, $start);
+        $this->assertSame($expected, $start);
     }
 
     /**
@@ -89,7 +89,7 @@ class RestrictedPermutationWithRepetitionTest extends AbstractUnitTestCase
             [ 8, 8, 8, 8, 8, 13, 13, 34 ],
         ];
 
-        $this->assertEquals($expected, $end);
+        $this->assertSame($expected, $end);
     }
 
     /**
@@ -102,7 +102,7 @@ class RestrictedPermutationWithRepetitionTest extends AbstractUnitTestCase
 
         $expected = 56448;
 
-        $this->assertEquals($expected, $count);
+        $this->assertSame($expected, $count);
     }
 
     /**
@@ -115,7 +115,7 @@ class RestrictedPermutationWithRepetitionTest extends AbstractUnitTestCase
 
         $expected = [ 21, 21, 21, 13, 8, 5, 5, 3, 3 ];
 
-        $this->assertEquals($expected, $first);
+        $this->assertSame($expected, $first);
     }
 
     /**
@@ -128,6 +128,6 @@ class RestrictedPermutationWithRepetitionTest extends AbstractUnitTestCase
 
         $expected = [ 3, 3, 5, 5, 8, 13, 21, 21, 21 ];
 
-        $this->assertEquals($expected, $last);
+        $this->assertSame($expected, $last);
     }
 }

--- a/tests/unit/Evaluation/AttackEvaluationTest.php
+++ b/tests/unit/Evaluation/AttackEvaluationTest.php
@@ -24,7 +24,7 @@ class AttackEvaluationTest extends AbstractUnitTestCase
             Symbol::BLACK => 0,
         ];
 
-        $this->assertEquals($expected, $attEvald);
+        $this->assertSame($expected, $attEvald);
     }
 
     /**
@@ -41,7 +41,7 @@ class AttackEvaluationTest extends AbstractUnitTestCase
             Symbol::BLACK => 0,
         ];
 
-        $this->assertEquals($expected, $attEvald);
+        $this->assertSame($expected, $attEvald);
     }
 
     /**
@@ -58,7 +58,7 @@ class AttackEvaluationTest extends AbstractUnitTestCase
             Symbol::BLACK => 0,
         ];
 
-        $this->assertEquals($expected, $attEvald);
+        $this->assertSame($expected, $attEvald);
     }
 
     /**
@@ -82,7 +82,7 @@ class AttackEvaluationTest extends AbstractUnitTestCase
             Symbol::BLACK => 2.33,
         ];
 
-        $this->assertEquals($expected, $attEvald);
+        $this->assertSame($expected, $attEvald);
     }
 
     /**
@@ -106,7 +106,7 @@ class AttackEvaluationTest extends AbstractUnitTestCase
             Symbol::BLACK => 0,
         ];
 
-        $this->assertEquals($expected, $attEvald);
+        $this->assertSame($expected, $attEvald);
     }
 
     /**
@@ -126,6 +126,6 @@ class AttackEvaluationTest extends AbstractUnitTestCase
             Symbol::BLACK => 0,
         ];
 
-        $this->assertEquals($expected, $attEvald);
+        $this->assertSame($expected, $attEvald);
     }
 }

--- a/tests/unit/Evaluation/BackwardPawnEvaluationTest.php
+++ b/tests/unit/Evaluation/BackwardPawnEvaluationTest.php
@@ -35,7 +35,7 @@ class BackwardPawnEvaluationTest extends AbstractUnitTestCase
 
         $backwardPawnEvald = (new BackwardPawnEvaluation($board))->evaluate();
 
-        $this->assertEquals($expected, $backwardPawnEvald);
+        $this->assertSame($expected, $backwardPawnEvald);
     }
 
     /**
@@ -63,6 +63,6 @@ class BackwardPawnEvaluationTest extends AbstractUnitTestCase
 
         $backwardPawnEvald = (new BackwardPawnEvaluation($board))->evaluate();
 
-        $this->assertEquals($expected, $backwardPawnEvald);
+        $this->assertSame($expected, $backwardPawnEvald);
     }
 }

--- a/tests/unit/Evaluation/CenterEvaluationTest.php
+++ b/tests/unit/Evaluation/CenterEvaluationTest.php
@@ -26,7 +26,7 @@ class CenterEvaluationTest extends AbstractUnitTestCase
 
         $ctrEvald = (new CenterEvaluation($board))->evaluate();
 
-        $this->assertEquals($expected, $ctrEvald);
+        $this->assertSame($expected, $ctrEvald);
     }
 
     /**
@@ -43,7 +43,7 @@ class CenterEvaluationTest extends AbstractUnitTestCase
 
         $ctrEvald = (new CenterEvaluation($board))->evaluate();
 
-        $this->assertEquals($expected, $ctrEvald);
+        $this->assertSame($expected, $ctrEvald);
     }
 
     /**
@@ -60,6 +60,6 @@ class CenterEvaluationTest extends AbstractUnitTestCase
 
         $ctrEvald = (new CenterEvaluation($board))->evaluate();
 
-        $this->assertEquals($expected, $ctrEvald);
+        $this->assertSame($expected, $ctrEvald);
     }
 }

--- a/tests/unit/Evaluation/CheckmateInOneEvaluationTest.php
+++ b/tests/unit/Evaluation/CheckmateInOneEvaluationTest.php
@@ -24,7 +24,7 @@ class CheckmateInOneEvaluationTest extends AbstractUnitTestCase
 
         $checkmateEvald = (new CheckmateInOneEvaluation($board))->evaluate();
 
-        $this->assertEquals($expected, $checkmateEvald);
+        $this->assertSame($expected, $checkmateEvald);
     }
 
     /**
@@ -44,7 +44,7 @@ class CheckmateInOneEvaluationTest extends AbstractUnitTestCase
 
         $checkmateEvald = (new CheckmateInOneEvaluation($board))->evaluate();
 
-        $this->assertEquals($expected, $checkmateEvald);
+        $this->assertSame($expected, $checkmateEvald);
     }
 
     /**
@@ -67,6 +67,6 @@ class CheckmateInOneEvaluationTest extends AbstractUnitTestCase
 
         $checkmateEvald = (new CheckmateInOneEvaluation($board))->evaluate();
 
-        $this->assertEquals($expected, $checkmateEvald);
+        $this->assertSame($expected, $checkmateEvald);
     }
 }

--- a/tests/unit/Evaluation/ConnectivityEvaluationTest.php
+++ b/tests/unit/Evaluation/ConnectivityEvaluationTest.php
@@ -22,7 +22,7 @@ class ConnectivityEvaluationTest extends AbstractUnitTestCase
             Symbol::BLACK => 20,
         ];
 
-        $this->assertEquals($expected, $connEvald);
+        $this->assertSame($expected, $connEvald);
     }
 
     /**
@@ -39,6 +39,6 @@ class ConnectivityEvaluationTest extends AbstractUnitTestCase
 
         $connEvald = (new ConnectivityEvaluation($board))->evaluate();
 
-        $this->assertEquals($expected, $connEvald);
+        $this->assertSame($expected, $connEvald);
     }
 }

--- a/tests/unit/Evaluation/DefenseEvaluationTest.php
+++ b/tests/unit/Evaluation/DefenseEvaluationTest.php
@@ -37,6 +37,6 @@ class DefenseEvaluationTest extends AbstractUnitTestCase
             ],
         ];
 
-        $this->assertEquals($expected, $defenseEvald);
+        $this->assertSame($expected, $defenseEvald);
     }
 }

--- a/tests/unit/Evaluation/DoubledPawnEvaluationTest.php
+++ b/tests/unit/Evaluation/DoubledPawnEvaluationTest.php
@@ -34,7 +34,7 @@ class DoubledPawnEvaluationTest extends AbstractUnitTestCase
 
         $doubledPawnEvald = (new DoubledPawnEvaluation($board))->evaluate();
 
-        $this->assertEquals($expected, $doubledPawnEvald);
+        $this->assertSame($expected, $doubledPawnEvald);
     }
 
     /**
@@ -62,6 +62,6 @@ class DoubledPawnEvaluationTest extends AbstractUnitTestCase
 
         $doubledPawnEvald = (new DoubledPawnEvaluation($board))->evaluate();
 
-        $this->assertEquals($expected, $doubledPawnEvald);
+        $this->assertSame($expected, $doubledPawnEvald);
     }
 }

--- a/tests/unit/Evaluation/IsolatedPawnEvaluationTest.php
+++ b/tests/unit/Evaluation/IsolatedPawnEvaluationTest.php
@@ -34,7 +34,7 @@ class IsolatedPawnEvaluationTest extends AbstractUnitTestCase
 
         $isolatedPawnEvald = (new IsolatedPawnEvaluation($board))->evaluate();
 
-        $this->assertEquals($expected, $isolatedPawnEvald);
+        $this->assertSame($expected, $isolatedPawnEvald);
     }
 
     /**
@@ -62,7 +62,7 @@ class IsolatedPawnEvaluationTest extends AbstractUnitTestCase
 
         $isolatedPawnEvald = (new IsolatedPawnEvaluation($board))->evaluate();
 
-        $this->assertEquals($expected, $isolatedPawnEvald);
+        $this->assertSame($expected, $isolatedPawnEvald);
     }
 
     /**
@@ -90,6 +90,6 @@ class IsolatedPawnEvaluationTest extends AbstractUnitTestCase
 
         $isolatedPawnEvald = (new IsolatedPawnEvaluation($board))->evaluate();
 
-        $this->assertEquals($expected, $isolatedPawnEvald);
+        $this->assertSame($expected, $isolatedPawnEvald);
     }
 }

--- a/tests/unit/Evaluation/KingSafetyEvaluationTest.php
+++ b/tests/unit/Evaluation/KingSafetyEvaluationTest.php
@@ -23,7 +23,7 @@ class KingSafetyEvaluationTest extends AbstractUnitTestCase
             Symbol::BLACK => 1,
         ];
 
-        $this->assertEquals($expected, $kSafetyEvald);
+        $this->assertSame($expected, $kSafetyEvald);
     }
 
     /**
@@ -40,7 +40,7 @@ class KingSafetyEvaluationTest extends AbstractUnitTestCase
             Symbol::BLACK => 1,
         ];
 
-        $this->assertEquals($expected, $kSafetyEvald);
+        $this->assertSame($expected, $kSafetyEvald);
     }
 
     /**
@@ -57,6 +57,6 @@ class KingSafetyEvaluationTest extends AbstractUnitTestCase
             Symbol::BLACK => 1,
         ];
 
-        $this->assertEquals($expected, $kSafetyEvald);
+        $this->assertSame($expected, $kSafetyEvald);
     }
 }

--- a/tests/unit/Evaluation/MaterialEvaluationTest.php
+++ b/tests/unit/Evaluation/MaterialEvaluationTest.php
@@ -42,7 +42,7 @@ class MaterialEvaluationTest extends AbstractUnitTestCase
 
         $mtlEvald = (new MaterialEvaluation($board))->evaluate();
 
-        $this->assertEquals($expected, $mtlEvald);
+        $this->assertSame($expected, $mtlEvald);
     }
 
     /**

--- a/tests/unit/Evaluation/PassedPawnEvaluationTest.php
+++ b/tests/unit/Evaluation/PassedPawnEvaluationTest.php
@@ -34,7 +34,7 @@ class PassedPawnEvaluationTest extends AbstractUnitTestCase
 
         $passedPawnEvald = (new PassedPawnEvaluation($board))->evaluate();
 
-        $this->assertEquals($expected, $passedPawnEvald);
+        $this->assertSame($expected, $passedPawnEvald);
     }
 
     /**
@@ -62,7 +62,7 @@ class PassedPawnEvaluationTest extends AbstractUnitTestCase
 
         $passedPawnEvald = (new PassedPawnEvaluation($board))->evaluate();
 
-        $this->assertEquals($expected, $passedPawnEvald);
+        $this->assertSame($expected, $passedPawnEvald);
     }
 
     /**
@@ -90,6 +90,6 @@ class PassedPawnEvaluationTest extends AbstractUnitTestCase
 
         $passedPawnEvald = (new PassedPawnEvaluation($board))->evaluate();
 
-        $this->assertEquals($expected, $passedPawnEvald);
+        $this->assertSame($expected, $passedPawnEvald);
     }
 }

--- a/tests/unit/Evaluation/PressureEvaluationTest.php
+++ b/tests/unit/Evaluation/PressureEvaluationTest.php
@@ -24,7 +24,7 @@ class PressureEvaluationTest extends AbstractUnitTestCase
             Symbol::BLACK => [],
         ];
 
-        $this->assertEquals($expected, $pressEvald);
+        $this->assertSame($expected, $pressEvald);
     }
 
     /**
@@ -41,7 +41,7 @@ class PressureEvaluationTest extends AbstractUnitTestCase
             Symbol::BLACK => ['e4'],
         ];
 
-        $this->assertEquals($expected, $pressEvald);
+        $this->assertSame($expected, $pressEvald);
     }
 
     /**
@@ -58,7 +58,7 @@ class PressureEvaluationTest extends AbstractUnitTestCase
             Symbol::BLACK => ['c3'],
         ];
 
-        $this->assertEquals($expected, $pressEvald);
+        $this->assertSame($expected, $pressEvald);
     }
 
     /**
@@ -82,6 +82,6 @@ class PressureEvaluationTest extends AbstractUnitTestCase
             Symbol::BLACK => ['b5', 'e5'],
         ];
 
-        $this->assertEquals($expected, $pressEvald);
+        $this->assertSame($expected, $pressEvald);
     }
 }

--- a/tests/unit/Evaluation/SpaceEvaluationTest.php
+++ b/tests/unit/Evaluation/SpaceEvaluationTest.php
@@ -27,7 +27,7 @@ class SpaceEvaluationTest extends AbstractUnitTestCase
             ],
         ];
 
-        $this->assertEquals($expected, $spEvald);
+        $this->assertSame($expected, $spEvald);
     }
 
     /**
@@ -52,7 +52,7 @@ class SpaceEvaluationTest extends AbstractUnitTestCase
             ],
         ];
 
-        $this->assertEquals($expected, $spEvald);
+        $this->assertSame($expected, $spEvald);
     }
 
     /**
@@ -77,6 +77,6 @@ class SpaceEvaluationTest extends AbstractUnitTestCase
             ],
         ];
 
-        $this->assertEquals($expected, $spEvald);
+        $this->assertSame($expected, $spEvald);
     }
 }

--- a/tests/unit/Evaluation/SquareEvaluationTest.php
+++ b/tests/unit/Evaluation/SquareEvaluationTest.php
@@ -28,6 +28,6 @@ class SquareEvaluationTest extends AbstractUnitTestCase
             'h3', 'h4', 'h5', 'h6',
         ];
 
-        $this->assertEquals($expected, $sqEvald);
+        $this->assertSame($expected, $sqEvald);
     }
 }

--- a/tests/unit/Evaluation/TacticsEvaluationTest.php
+++ b/tests/unit/Evaluation/TacticsEvaluationTest.php
@@ -24,7 +24,7 @@ class TacticsEvaluationTest extends AbstractUnitTestCase
             Symbol::BLACK => 0,
         ];
 
-        $this->assertEquals($expected, $attEvald);
+        $this->assertSame($expected, $attEvald);
     }
 
     /**
@@ -43,7 +43,7 @@ class TacticsEvaluationTest extends AbstractUnitTestCase
             Symbol::BLACK => 1,
         ];
 
-        $this->assertEquals($expected, $tacticsEvald);
+        $this->assertSame($expected, $tacticsEvald);
     }
 
     /**
@@ -60,7 +60,7 @@ class TacticsEvaluationTest extends AbstractUnitTestCase
             Symbol::BLACK => 0,
         ];
 
-        $this->assertEquals($expected, $attEvald);
+        $this->assertSame($expected, $attEvald);
     }
 
     /**
@@ -77,7 +77,7 @@ class TacticsEvaluationTest extends AbstractUnitTestCase
             Symbol::BLACK => 0,
         ];
 
-        $this->assertEquals($expected, $attEvald);
+        $this->assertSame($expected, $attEvald);
     }
 
     /**
@@ -101,7 +101,7 @@ class TacticsEvaluationTest extends AbstractUnitTestCase
             Symbol::BLACK => 6.53,
         ];
 
-        $this->assertEquals($expected, $tacticsEvald);
+        $this->assertSame($expected, $tacticsEvald);
     }
 
     /**
@@ -125,6 +125,6 @@ class TacticsEvaluationTest extends AbstractUnitTestCase
             Symbol::BLACK => 0,
         ];
 
-        $this->assertEquals($expected, $tacticsEvald);
+        $this->assertSame($expected, $tacticsEvald);
     }
 }

--- a/tests/unit/Event/CheckTest.php
+++ b/tests/unit/Event/CheckTest.php
@@ -19,8 +19,8 @@ class CheckTest extends AbstractUnitTestCase
     {
         $board = (new FoolCheckmate(new Board()))->play();
 
-        $this->assertEquals(0, (new CheckEvent($board))->capture(Symbol::WHITE));
-        $this->assertEquals(1, (new CheckEvent($board))->capture(Symbol::BLACK));
+        $this->assertSame(0, (new CheckEvent($board))->capture(Symbol::WHITE));
+        $this->assertSame(1, (new CheckEvent($board))->capture(Symbol::BLACK));
     }
 
     /**
@@ -30,8 +30,8 @@ class CheckTest extends AbstractUnitTestCase
     {
         $board = (new ScholarCheckmate(new Board()))->play();
 
-        $this->assertEquals(1, (new CheckEvent($board))->capture(Symbol::WHITE));
-        $this->assertEquals(0, (new CheckEvent($board))->capture(Symbol::BLACK));
+        $this->assertSame(1, (new CheckEvent($board))->capture(Symbol::WHITE));
+        $this->assertSame(0, (new CheckEvent($board))->capture(Symbol::BLACK));
     }
 
     /**
@@ -41,7 +41,7 @@ class CheckTest extends AbstractUnitTestCase
     {
         $board = (new RuyLopezLucenaDefense(new Board()))->play();
 
-        $this->assertEquals(0, (new CheckEvent($board))->capture(Symbol::WHITE));
-        $this->assertEquals(0, (new CheckEvent($board))->capture(Symbol::BLACK));
+        $this->assertSame(0, (new CheckEvent($board))->capture(Symbol::WHITE));
+        $this->assertSame(0, (new CheckEvent($board))->capture(Symbol::BLACK));
     }
 }

--- a/tests/unit/Event/MajorPieceThreatenedByPawnTest.php
+++ b/tests/unit/Event/MajorPieceThreatenedByPawnTest.php
@@ -18,18 +18,18 @@ class MajorPieceThreatenedByPawnTest extends AbstractUnitTestCase
         $board = new Board();
 
         $board->play(Convert::toStdObj(Symbol::WHITE, 'e4'));
-        $this->assertEquals(0, (new MajorPieceThreatenedByPawnEvent($board))->capture(Symbol::WHITE));
+        $this->assertSame(0, (new MajorPieceThreatenedByPawnEvent($board))->capture(Symbol::WHITE));
 
         $board->play(Convert::toStdObj(Symbol::BLACK, 'e5'));
-        $this->assertEquals(0, (new MajorPieceThreatenedByPawnEvent($board))->capture(Symbol::BLACK));
+        $this->assertSame(0, (new MajorPieceThreatenedByPawnEvent($board))->capture(Symbol::BLACK));
 
         $board->play(Convert::toStdObj(Symbol::WHITE, 'Nc3'));
-        $this->assertEquals(0, (new MajorPieceThreatenedByPawnEvent($board))->capture(Symbol::WHITE));
+        $this->assertSame(0, (new MajorPieceThreatenedByPawnEvent($board))->capture(Symbol::WHITE));
 
         $board->play(Convert::toStdObj(Symbol::BLACK, 'Qg5'));
-        $this->assertEquals(0, (new MajorPieceThreatenedByPawnEvent($board))->capture(Symbol::BLACK));
+        $this->assertSame(0, (new MajorPieceThreatenedByPawnEvent($board))->capture(Symbol::BLACK));
 
         $board->play(Convert::toStdObj(Symbol::WHITE, 'f4'));
-        $this->assertEquals(1, (new MajorPieceThreatenedByPawnEvent($board))->capture(Symbol::WHITE));
+        $this->assertSame(1, (new MajorPieceThreatenedByPawnEvent($board))->capture(Symbol::WHITE));
     }
 }

--- a/tests/unit/Event/MinorPieceThreatenedByPawnTest.php
+++ b/tests/unit/Event/MinorPieceThreatenedByPawnTest.php
@@ -18,33 +18,33 @@ class MinorPieceThreatenedByPawnTest extends AbstractUnitTestCase
         $board = new Board();
 
         $board->play(Convert::toStdObj(Symbol::WHITE, 'Nf3'));
-        $this->assertEquals(0, (new MinorPieceThreatenedByPawnEvent($board))->capture(Symbol::WHITE));
+        $this->assertSame(0, (new MinorPieceThreatenedByPawnEvent($board))->capture(Symbol::WHITE));
 
         $board->play(Convert::toStdObj(Symbol::BLACK, 'e5'));
-        $this->assertEquals(0, (new MinorPieceThreatenedByPawnEvent($board))->capture(Symbol::BLACK));
+        $this->assertSame(0, (new MinorPieceThreatenedByPawnEvent($board))->capture(Symbol::BLACK));
 
         $board->play(Convert::toStdObj(Symbol::WHITE, 'Nc3'));
-        $this->assertEquals(0, (new MinorPieceThreatenedByPawnEvent($board))->capture(Symbol::WHITE));
+        $this->assertSame(0, (new MinorPieceThreatenedByPawnEvent($board))->capture(Symbol::WHITE));
 
         $board->play(Convert::toStdObj(Symbol::BLACK, 'd5'));
-        $this->assertEquals(0, (new MinorPieceThreatenedByPawnEvent($board))->capture(Symbol::BLACK));
+        $this->assertSame(0, (new MinorPieceThreatenedByPawnEvent($board))->capture(Symbol::BLACK));
 
         $board->play(Convert::toStdObj(Symbol::WHITE, 'g3'));
-        $this->assertEquals(0, (new MinorPieceThreatenedByPawnEvent($board))->capture(Symbol::WHITE));
+        $this->assertSame(0, (new MinorPieceThreatenedByPawnEvent($board))->capture(Symbol::WHITE));
 
         $board->play(Convert::toStdObj(Symbol::BLACK, 'e4'));
-        $this->assertEquals(1, (new MinorPieceThreatenedByPawnEvent($board))->capture(Symbol::BLACK));
+        $this->assertSame(1, (new MinorPieceThreatenedByPawnEvent($board))->capture(Symbol::BLACK));
 
         $board->play(Convert::toStdObj(Symbol::WHITE, 'Bg2'));
-        $this->assertEquals(0, (new MinorPieceThreatenedByPawnEvent($board))->capture(Symbol::WHITE));
+        $this->assertSame(0, (new MinorPieceThreatenedByPawnEvent($board))->capture(Symbol::WHITE));
 
         $board->play(Convert::toStdObj(Symbol::BLACK, 'd4'));
-        $this->assertEquals(1, (new MinorPieceThreatenedByPawnEvent($board))->capture(Symbol::BLACK));
+        $this->assertSame(1, (new MinorPieceThreatenedByPawnEvent($board))->capture(Symbol::BLACK));
 
         $board->play(Convert::toStdObj(Symbol::WHITE, 'O-O'));
-        $this->assertEquals(0, (new MinorPieceThreatenedByPawnEvent($board))->capture(Symbol::WHITE));
+        $this->assertSame(0, (new MinorPieceThreatenedByPawnEvent($board))->capture(Symbol::WHITE));
 
         $board->play(Convert::toStdObj(Symbol::BLACK, 'd3'));
-        $this->assertEquals(0, (new MinorPieceThreatenedByPawnEvent($board))->capture(Symbol::BLACK));
+        $this->assertSame(0, (new MinorPieceThreatenedByPawnEvent($board))->capture(Symbol::BLACK));
     }
 }

--- a/tests/unit/Event/PieceCaptureTest.php
+++ b/tests/unit/Event/PieceCaptureTest.php
@@ -19,8 +19,8 @@ class PieceCaptureTest extends AbstractUnitTestCase
     {
         $board = (new FoolCheckmate(new Board()))->play();
 
-        $this->assertEquals(0, (new PieceCaptureEvent($board))->capture(Symbol::WHITE));
-        $this->assertEquals(0, (new PieceCaptureEvent($board))->capture(Symbol::BLACK));
+        $this->assertSame(0, (new PieceCaptureEvent($board))->capture(Symbol::WHITE));
+        $this->assertSame(0, (new PieceCaptureEvent($board))->capture(Symbol::BLACK));
     }
 
     /**
@@ -30,8 +30,8 @@ class PieceCaptureTest extends AbstractUnitTestCase
     {
         $board = (new ScholarCheckmate(new Board()))->play();
 
-        $this->assertEquals(1, (new PieceCaptureEvent($board))->capture(Symbol::WHITE));
-        $this->assertEquals(0, (new PieceCaptureEvent($board))->capture(Symbol::BLACK));
+        $this->assertSame(1, (new PieceCaptureEvent($board))->capture(Symbol::WHITE));
+        $this->assertSame(0, (new PieceCaptureEvent($board))->capture(Symbol::BLACK));
     }
 
     /**
@@ -41,7 +41,7 @@ class PieceCaptureTest extends AbstractUnitTestCase
     {
         $board = (new RuyLopezLucenaDefense(new Board()))->play();
 
-        $this->assertEquals(0, (new PieceCaptureEvent($board))->capture(Symbol::WHITE));
-        $this->assertEquals(0, (new PieceCaptureEvent($board))->capture(Symbol::BLACK));
+        $this->assertSame(0, (new PieceCaptureEvent($board))->capture(Symbol::WHITE));
+        $this->assertSame(0, (new PieceCaptureEvent($board))->capture(Symbol::BLACK));
     }
 }

--- a/tests/unit/Event/PromotionTest.php
+++ b/tests/unit/Event/PromotionTest.php
@@ -43,16 +43,16 @@ class PromotionTest extends AbstractUnitTestCase
         $board = new Board($pieces, $castling);
 
         $board->play(Convert::toStdObj(Symbol::WHITE, 'b7'));
-        $this->assertEquals(0, (new PromotionEvent($board))->capture(Symbol::WHITE));
+        $this->assertSame(0, (new PromotionEvent($board))->capture(Symbol::WHITE));
 
         $board->play(Convert::toStdObj(Symbol::BLACK, 'b2'));
-        $this->assertEquals(0, (new PromotionEvent($board))->capture(Symbol::BLACK));
+        $this->assertSame(0, (new PromotionEvent($board))->capture(Symbol::BLACK));
 
         $board->play(Convert::toStdObj(Symbol::WHITE, 'b8'));
-        $this->assertEquals(1, (new PromotionEvent($board))->capture(Symbol::WHITE));
+        $this->assertSame(1, (new PromotionEvent($board))->capture(Symbol::WHITE));
 
         $board->play(Convert::toStdObj(Symbol::BLACK, 'b1'));
-        $this->assertEquals(1, (new PromotionEvent($board))->capture(Symbol::BLACK));
+        $this->assertSame(1, (new PromotionEvent($board))->capture(Symbol::BLACK));
     }
 
     /**
@@ -85,21 +85,21 @@ class PromotionTest extends AbstractUnitTestCase
         $board = new Board($pieces, $castling);
 
         $board->play(Convert::toStdObj(Symbol::WHITE, 'b7'));
-        $this->assertEquals(0, (new PromotionEvent($board))->capture(Symbol::WHITE));
+        $this->assertSame(0, (new PromotionEvent($board))->capture(Symbol::WHITE));
 
         $board->play(Convert::toStdObj(Symbol::BLACK, 'g2'));
-        $this->assertEquals(0, (new PromotionEvent($board))->capture(Symbol::BLACK));
+        $this->assertSame(0, (new PromotionEvent($board))->capture(Symbol::BLACK));
 
         $board->play(Convert::toStdObj(Symbol::WHITE, 'bxa8'));
-        $this->assertEquals(1, (new PromotionEvent($board))->capture(Symbol::WHITE));
+        $this->assertSame(1, (new PromotionEvent($board))->capture(Symbol::WHITE));
 
         $board->play(Convert::toStdObj(Symbol::BLACK, 'gxh1'));
-        $this->assertEquals(1, (new PromotionEvent($board))->capture(Symbol::BLACK));
+        $this->assertSame(1, (new PromotionEvent($board))->capture(Symbol::BLACK));
 
         $board->play(Convert::toStdObj(Symbol::WHITE, 'Qxh1'));
-        $this->assertEquals(0, (new PromotionEvent($board))->capture(Symbol::WHITE));
+        $this->assertSame(0, (new PromotionEvent($board))->capture(Symbol::WHITE));
 
         $board->play(Convert::toStdObj(Symbol::BLACK, 'Ke5'));
-        $this->assertEquals(0, (new PromotionEvent($board))->capture(Symbol::BLACK));
+        $this->assertSame(0, (new PromotionEvent($board))->capture(Symbol::BLACK));
     }
 }

--- a/tests/unit/FEN/BoardToStringTest.php
+++ b/tests/unit/FEN/BoardToStringTest.php
@@ -24,7 +24,7 @@ class BoardToStringTest extends AbstractUnitTestCase
 
         $expected = 'rnbqkbnr/pppppppp/8/8/4P3/8/PPPP1PPP/RNBQKBNR b KQkq e3';
 
-        $this->assertEquals($expected, $boardToString);
+        $this->assertSame($expected, $boardToString);
     }
 
     /**
@@ -40,7 +40,7 @@ class BoardToStringTest extends AbstractUnitTestCase
 
         $expected = 'rnbqkbnr/pppp1ppp/8/4p3/4P3/8/PPPP1PPP/RNBQKBNR w KQkq e6';
 
-        $this->assertEquals($expected, $boardToString);
+        $this->assertSame($expected, $boardToString);
     }
 
     /**
@@ -54,7 +54,7 @@ class BoardToStringTest extends AbstractUnitTestCase
 
         $expected = 'rn1qkb1r/4pp1p/3p1np1/2pP4/4P3/2N3P1/PP3P1P/R1BQ1KNR b kq -';
 
-        $this->assertEquals($expected, $boardToString);
+        $this->assertSame($expected, $boardToString);
     }
 
     /**
@@ -68,7 +68,7 @@ class BoardToStringTest extends AbstractUnitTestCase
 
         $expected = 'r1b1kbnr/1pp2ppp/p1p5/8/3NP3/8/PPP2PPP/RNB1K2R b KQkq -';
 
-        $this->assertEquals($expected, $boardToString);
+        $this->assertSame($expected, $boardToString);
     }
 
     /**
@@ -89,7 +89,7 @@ class BoardToStringTest extends AbstractUnitTestCase
 
         $expected = 'r1bqk1nr/ppppbppp/2n5/4p3/4P3/5N2/PPPPBPPP/RNBQ1RK1 b kq -';
 
-        $this->assertEquals($expected, $boardToString);
+        $this->assertSame($expected, $boardToString);
     }
 
     /**
@@ -114,6 +114,6 @@ class BoardToStringTest extends AbstractUnitTestCase
 
         $expected = 'r1bqkbnR/pppp1p2/2n5/4p1p1/2B1P3/5N2/PPPP1PP1/RNBQK3 b Qq -';
 
-        $this->assertEquals($expected, $boardToString);
+        $this->assertSame($expected, $boardToString);
     }
 }

--- a/tests/unit/FEN/ShortenedStringToPgnTest.php
+++ b/tests/unit/FEN/ShortenedStringToPgnTest.php
@@ -22,7 +22,7 @@ class ShortenedStringToPgnTest extends AbstractUnitTestCase
             Symbol::WHITE => 'e4',
         ];
 
-        $this->assertEquals($expected, $pgn);
+        $this->assertSame($expected, $pgn);
     }
 
     /**
@@ -39,7 +39,7 @@ class ShortenedStringToPgnTest extends AbstractUnitTestCase
             Symbol::WHITE => 'Nf3',
         ];
 
-        $this->assertEquals($expected, $pgn);
+        $this->assertSame($expected, $pgn);
     }
 
     /**
@@ -56,6 +56,6 @@ class ShortenedStringToPgnTest extends AbstractUnitTestCase
             Symbol::WHITE => 'Qg4',
         ];
 
-        $this->assertEquals($expected, $pgn);
+        $this->assertSame($expected, $pgn);
     }
 }

--- a/tests/unit/FEN/StringToBoardTest.php
+++ b/tests/unit/FEN/StringToBoardTest.php
@@ -33,7 +33,7 @@ class StringToBoardTest extends AbstractUnitTestCase
             0 => [ ' R ', ' N ', ' B ', ' Q ', ' K ', ' B ', ' N ', ' R ' ],
         ];
 
-        $this->assertEquals($expected, $array);
+        $this->assertSame($expected, $array);
     }
 
     /**
@@ -57,7 +57,7 @@ class StringToBoardTest extends AbstractUnitTestCase
             0 => [ ' R ', ' N ', ' B ', ' Q ', ' K ', ' B ', ' N ', ' R ' ],
         ];
 
-        $this->assertEquals($expected, $array);
+        $this->assertSame($expected, $array);
     }
 
     /**
@@ -81,7 +81,7 @@ class StringToBoardTest extends AbstractUnitTestCase
             0 => [' r ', ' n ', ' b ', ' k ', ' q ', ' b ', ' n ', ' r '],
         ];
 
-        $this->assertEquals($expected, $array);
+        $this->assertSame($expected, $array);
     }
 
     /**
@@ -105,7 +105,7 @@ class StringToBoardTest extends AbstractUnitTestCase
             0 => [ ' R ', ' . ', ' B ', ' Q ', ' . ', ' K ', ' N ', ' R ' ],
         ];
 
-        $this->assertEquals($expected, $array);
+        $this->assertSame($expected, $array);
     }
 
     /**
@@ -129,7 +129,7 @@ class StringToBoardTest extends AbstractUnitTestCase
             0 => [ ' R ', ' N ', ' B ', ' . ', ' K ', ' . ', ' . ', ' R ' ],
         ];
 
-        $this->assertEquals($expected, $array);
+        $this->assertSame($expected, $array);
     }
 
     /**
@@ -153,7 +153,7 @@ class StringToBoardTest extends AbstractUnitTestCase
             0 => [ ' R ', ' . ', ' B ', ' Q ', ' K ', ' . ', ' N ', ' R ' ],
         ];
 
-        $this->assertEquals($expected, $array);
+        $this->assertSame($expected, $array);
     }
 
     /**
@@ -177,7 +177,7 @@ class StringToBoardTest extends AbstractUnitTestCase
             0 => [' r ', ' n ', ' . ', ' k ', ' q ', ' b ', ' . ', ' r '],
         ];
 
-        $this->assertEquals($expected, $array);
+        $this->assertSame($expected, $array);
     }
 
     /**
@@ -204,7 +204,7 @@ class StringToBoardTest extends AbstractUnitTestCase
             0 => [ ' R ', ' N ', ' B ', ' Q ', ' K ', ' B ', ' . ', ' R ' ],
         ];
 
-        $this->assertEquals($expected, $array);
+        $this->assertSame($expected, $array);
     }
 
     /**
@@ -215,7 +215,7 @@ class StringToBoardTest extends AbstractUnitTestCase
         $board = (new StringToBoard('rnbqkbnr/pppp1ppp/8/4p3/4P3/8/PPPP1PPP/RNBQKBNR w KQkq e6 0 2'))
             ->create();
 
-        $this->assertEquals(false, $board->play(Convert::toStdObj(Symbol::WHITE, 'Nc6')));
+        $this->assertFalse($board->play(Convert::toStdObj(Symbol::WHITE, 'Nc6')));
     }
 
     /**
@@ -241,8 +241,8 @@ class StringToBoardTest extends AbstractUnitTestCase
 
         $legalMoves = $board->getPieceByPosition('e5')->getLegalMoves();
 
-        $this->assertEquals($expected, $array);
-        $this->assertEquals($legalMoves, ['e6' , 'f6']);
+        $this->assertSame($expected, $array);
+        $this->assertSame($legalMoves, ['e6' , 'f6']);
     }
 
     /**
@@ -253,7 +253,7 @@ class StringToBoardTest extends AbstractUnitTestCase
         $board = (new StringToBoard('rnbqkbnr/pp1pp1pp/8/2p1Pp2/8/8/PPPP1PPP/RNBQKBNR w KQkq f6 0 3'))
             ->create();
 
-        $this->assertEquals(true, $board->play(Convert::toStdObj(Symbol::WHITE, 'exf6')));
+        $this->assertTrue($board->play(Convert::toStdObj(Symbol::WHITE, 'exf6')));
     }
 
     /**
@@ -277,7 +277,7 @@ class StringToBoardTest extends AbstractUnitTestCase
             0 => [ ' . ', ' . ', ' R ', ' Q ', ' . ', ' R ', ' . ', ' K ' ],
         ];
 
-        $this->assertEquals($expected, $array);
+        $this->assertSame($expected, $array);
     }
 
     /**
@@ -303,7 +303,7 @@ class StringToBoardTest extends AbstractUnitTestCase
             0 => [ ' . ', ' . ', ' R ', ' . ', ' . ', ' R ', ' . ', ' K ' ],
         ];
 
-        $this->assertEquals($expected, $array);
+        $this->assertSame($expected, $array);
     }
 
     /**
@@ -330,7 +330,7 @@ class StringToBoardTest extends AbstractUnitTestCase
             0 => [ ' . ', ' . ', ' R ', ' . ', ' . ', ' R ', ' . ', ' K ' ],
         ];
 
-        $this->assertEquals($expected, $array);
+        $this->assertSame($expected, $array);
     }
 
     /**
@@ -347,7 +347,7 @@ class StringToBoardTest extends AbstractUnitTestCase
 
         $expected = ['a6', 'a5'];
 
-        $this->assertEquals($expected, $legalMoves);
+        $this->assertSame($expected, $legalMoves);
     }
 
     /**

--- a/tests/unit/FEN/StringToPgnTest.php
+++ b/tests/unit/FEN/StringToPgnTest.php
@@ -22,7 +22,7 @@ class StringToPgnTest extends AbstractUnitTestCase
             Symbol::WHITE => 'e4',
         ];
 
-        $this->assertEquals($expected, $pgn);
+        $this->assertSame($expected, $pgn);
     }
 
     /**
@@ -39,6 +39,6 @@ class StringToPgnTest extends AbstractUnitTestCase
             Symbol::WHITE => 'Nf3',
         ];
 
-        $this->assertEquals($expected, $pgn);
+        $this->assertSame($expected, $pgn);
     }
 }

--- a/tests/unit/FEN/Validate/CastlingAbilityTest.php
+++ b/tests/unit/FEN/Validate/CastlingAbilityTest.php
@@ -73,7 +73,7 @@ class CastlingAbilityTest extends AbstractUnitTestCase
      */
     public function start_w_KQkq()
     {
-        $this->assertEquals('KQkq', Validate::castling('KQkq'));
+        $this->assertSame('KQkq', Validate::castling('KQkq'));
     }
 
     /**
@@ -81,7 +81,7 @@ class CastlingAbilityTest extends AbstractUnitTestCase
      */
     public function w_k()
     {
-        $this->assertEquals('K', Validate::castling('K'));
+        $this->assertSame('K', Validate::castling('K'));
     }
 
     /**
@@ -89,7 +89,7 @@ class CastlingAbilityTest extends AbstractUnitTestCase
      */
     public function w_q()
     {
-        $this->assertEquals('Q', Validate::castling('Q'));
+        $this->assertSame('Q', Validate::castling('Q'));
     }
 
     /**
@@ -97,7 +97,7 @@ class CastlingAbilityTest extends AbstractUnitTestCase
      */
     public function b_k()
     {
-        $this->assertEquals('k', Validate::castling('k'));
+        $this->assertSame('k', Validate::castling('k'));
     }
 
     /**
@@ -105,7 +105,7 @@ class CastlingAbilityTest extends AbstractUnitTestCase
      */
     public function b_q()
     {
-        $this->assertEquals('q', Validate::castling('q'));
+        $this->assertSame('q', Validate::castling('q'));
     }
 
     /**
@@ -113,7 +113,7 @@ class CastlingAbilityTest extends AbstractUnitTestCase
      */
     public function w_kq()
     {
-        $this->assertEquals('KQ', Validate::castling('KQ'));
+        $this->assertSame('KQ', Validate::castling('KQ'));
     }
 
     /**
@@ -121,7 +121,7 @@ class CastlingAbilityTest extends AbstractUnitTestCase
      */
     public function b_kq()
     {
-        $this->assertEquals('kq', Validate::castling('kq'));
+        $this->assertSame('kq', Validate::castling('kq'));
     }
 
     /**
@@ -129,6 +129,6 @@ class CastlingAbilityTest extends AbstractUnitTestCase
      */
     public function hyphen()
     {
-        $this->assertEquals('-', Validate::castling('-'));
+        $this->assertSame('-', Validate::castling('-'));
     }
 }

--- a/tests/unit/FEN/Validate/ColorTest.php
+++ b/tests/unit/FEN/Validate/ColorTest.php
@@ -23,7 +23,7 @@ class ColorTest extends AbstractUnitTestCase
      */
     public function white()
     {
-        $this->assertEquals(Symbol::WHITE, Validate::color(Symbol::WHITE));
+        $this->assertSame(Symbol::WHITE, Validate::color(Symbol::WHITE));
     }
 
     /**
@@ -31,6 +31,6 @@ class ColorTest extends AbstractUnitTestCase
      */
     public function black()
     {
-        $this->assertEquals(Symbol::BLACK, Validate::color(Symbol::BLACK));
+        $this->assertSame(Symbol::BLACK, Validate::color(Symbol::BLACK));
     }
 }

--- a/tests/unit/FEN/Validate/SquareTest.php
+++ b/tests/unit/FEN/Validate/SquareTest.php
@@ -53,6 +53,6 @@ class SquareTest extends AbstractUnitTestCase
      */
     public function e4()
     {
-        $this->assertEquals(Validate::square('e4'), 'e4');
+        $this->assertSame(Validate::square('e4'), 'e4');
     }
 }

--- a/tests/unit/FEN/Validate/StringTest.php
+++ b/tests/unit/FEN/Validate/StringTest.php
@@ -35,7 +35,7 @@ class StringTest extends AbstractUnitTestCase
     {
         $string = '1rbq1rk1/p1b1nppp/1p2p3/8/1B1pN3/P2B4/1P3PPP/2RQ1R1K w - - bm Nf6+; id "position 01";';
 
-        $this->assertEquals($string, Validate::fen($string));
+        $this->assertSame($string, Validate::fen($string));
     }
 
     /**
@@ -45,6 +45,6 @@ class StringTest extends AbstractUnitTestCase
     {
         $string = '1rbq1rk1/p1b1nppp/1p2p3/8/1B1pN3/P2B4/1P3PPP/2RQ1R1K w - - bm Nf6+';
 
-        $this->assertEquals($string, Validate::fen($string));
+        $this->assertSame($string, Validate::fen($string));
     }
 }

--- a/tests/unit/Game/HeuristicPictureTest.php
+++ b/tests/unit/Game/HeuristicPictureTest.php
@@ -28,7 +28,7 @@ class HeuristicPictureTest extends AbstractUnitTestCase
 
         $picture = $game->heuristicPicture();
 
-        $this->assertEquals($expected, $picture);
+        $this->assertSame($expected, $picture);
     }
 
     /**
@@ -46,7 +46,7 @@ class HeuristicPictureTest extends AbstractUnitTestCase
 
         $balance = $game->heuristicPicture(true);
 
-        $this->assertEquals($expected, $balance);
+        $this->assertSame($expected, $balance);
     }
 
     /**
@@ -82,6 +82,6 @@ class HeuristicPictureTest extends AbstractUnitTestCase
 
         $balance = $game->heuristicPicture(true);
 
-        $this->assertEquals($expected, $balance);
+        $this->assertSame($expected, $balance);
     }
 }

--- a/tests/unit/Game/PlayTest.php
+++ b/tests/unit/Game/PlayTest.php
@@ -15,7 +15,7 @@ class PlayTest extends AbstractUnitTestCase
     {
         $game = new Game();
 
-        $this->assertEquals(true, $game->playFen('rnbqkbnr/pppppppp/8/8/4P3/8/PPPP1PPP/RNBQKBNR b'));
+        $this->assertTrue($game->playFen('rnbqkbnr/pppppppp/8/8/4P3/8/PPPP1PPP/RNBQKBNR b'));
     }
 
     /**
@@ -38,7 +38,7 @@ class PlayTest extends AbstractUnitTestCase
         $game->playFen('rnbqkbnr/pppppppp/8/8/4P3/8/PPPP1PPP/RNBQKBNR b');
 
         $this->assertIsObject($game->undoMove());
-        $this->assertEquals(false, $game->undoMove());
+        $this->assertNull($game->undoMove());
     }
 
     /**
@@ -49,7 +49,7 @@ class PlayTest extends AbstractUnitTestCase
         $game = new Game();
         $game->playFen('rnbqkbnr/pppppppp/8/8/4P3/8/PPPP1PPP/RNBQKBNR b');
 
-        $this->assertEquals(true, $game->playFen('rnbqkbnr/pppp1ppp/8/4p3/4P3/8/PPPP1PPP/RNBQKBNR w'));
+        $this->assertTrue($game->playFen('rnbqkbnr/pppp1ppp/8/4p3/4P3/8/PPPP1PPP/RNBQKBNR w'));
     }
 
     /**
@@ -60,7 +60,7 @@ class PlayTest extends AbstractUnitTestCase
         $game = new Game();
         $game->playFen('rnbqkbnr/pppppppp/8/8/4P3/8/PPPP1PPP/RNBQKBNR b');
 
-        $this->assertEquals(false, $game->playFen('rnbqk1nr/pppppppp/6b1/8/4P3/8/PPPP1PPP/RNBQKBNR w'));
+        $this->assertFalse($game->playFen('rnbqk1nr/pppppppp/6b1/8/4P3/8/PPPP1PPP/RNBQKBNR w'));
     }
 
     /**
@@ -72,7 +72,7 @@ class PlayTest extends AbstractUnitTestCase
         $game->play('w', 'e4');
         $game->play('b', 'e5');
 
-        $this->assertEquals(true, $game->playFen('rnbqkbnr/pppp1ppp/8/4p3/4P3/5N2/PPPP1PPP/RNBQKB1R b'));
+        $this->assertTrue($game->playFen('rnbqkbnr/pppp1ppp/8/4p3/4P3/5N2/PPPP1PPP/RNBQKB1R b'));
     }
 
     /**
@@ -102,7 +102,7 @@ class PlayTest extends AbstractUnitTestCase
         $game->playFen('rnbqkb1r/pppp1ppp/5n2/4p3/4P3/5N2/PPPPBPPP/RNBQK2R b');
         $game->playFen('rnbqk2r/ppppbppp/5n2/4p3/4P3/5N2/PPPPBPPP/RNBQK2R w');
 
-        $this->assertEquals('O-O', $game->playFen('rnbqk2r/ppppbppp/5n2/4p3/4P3/5N2/PPPPBPPP/RNBQ2KR b'));
+        $this->assertSame('O-O', $game->playFen('rnbqk2r/ppppbppp/5n2/4p3/4P3/5N2/PPPPBPPP/RNBQ2KR b'));
     }
 
     /**
@@ -111,13 +111,13 @@ class PlayTest extends AbstractUnitTestCase
     public function e4_e5_Nf3_Nf6_Bc4_Bc5_Ke2()
     {
         $game = new Game();
-        $this->assertEquals(true, $game->playFen('rnbqkbnr/pppppppp/8/8/4P3/8/PPPP1PPP/RNBQKBNR b'));
-        $this->assertEquals(true, $game->playFen('rnbqkbnr/pppp1ppp/8/4p3/4P3/8/PPPP1PPP/RNBQKBNR w'));
-        $this->assertEquals(true, $game->playFen('rnbqkbnr/pppp1ppp/8/4p3/4P3/5N2/PPPP1PPP/RNBQKB1R b'));
-        $this->assertEquals(true, $game->playFen('rnbqkb1r/pppp1ppp/5n2/4p3/4P3/5N2/PPPP1PPP/RNBQKB1R w'));
-        $this->assertEquals(true, $game->playFen('rnbqkb1r/pppp1ppp/5n2/4p3/2B1P3/5N2/PPPP1PPP/RNBQK2R b'));
-        $this->assertEquals(true, $game->playFen('rnbqk2r/pppp1ppp/5n2/2b1p3/2B1P3/5N2/PPPP1PPP/RNBQK2R w'));
-        $this->assertEquals(true, $game->playFen('rnbqk2r/pppp1ppp/5n2/2b1p3/2B1P3/5N2/PPPPKPPP/RNBQ3R b'));
+        $this->assertTrue($game->playFen('rnbqkbnr/pppppppp/8/8/4P3/8/PPPP1PPP/RNBQKBNR b'));
+        $this->assertTrue($game->playFen('rnbqkbnr/pppp1ppp/8/4p3/4P3/8/PPPP1PPP/RNBQKBNR w'));
+        $this->assertTrue($game->playFen('rnbqkbnr/pppp1ppp/8/4p3/4P3/5N2/PPPP1PPP/RNBQKB1R b'));
+        $this->assertTrue($game->playFen('rnbqkb1r/pppp1ppp/5n2/4p3/4P3/5N2/PPPP1PPP/RNBQKB1R w'));
+        $this->assertTrue($game->playFen('rnbqkb1r/pppp1ppp/5n2/4p3/2B1P3/5N2/PPPP1PPP/RNBQK2R b'));
+        $this->assertTrue($game->playFen('rnbqk2r/pppp1ppp/5n2/2b1p3/2B1P3/5N2/PPPP1PPP/RNBQK2R w'));
+        $this->assertTrue($game->playFen('rnbqk2r/pppp1ppp/5n2/2b1p3/2B1P3/5N2/PPPPKPPP/RNBQ3R b'));
     }
 
     /**
@@ -126,15 +126,15 @@ class PlayTest extends AbstractUnitTestCase
     public function e4_e5_Nf3_Nf6_Bc4_Bc5_Ke2_Ke7_Nc3()
     {
         $game = new Game();
-        $this->assertEquals(true, $game->playFen('rnbqkbnr/pppppppp/8/8/4P3/8/PPPP1PPP/RNBQKBNR b'));
-        $this->assertEquals(true, $game->playFen('rnbqkbnr/pppp1ppp/8/4p3/4P3/8/PPPP1PPP/RNBQKBNR w'));
-        $this->assertEquals(true, $game->playFen('rnbqkbnr/pppp1ppp/8/4p3/4P3/5N2/PPPP1PPP/RNBQKB1R b'));
-        $this->assertEquals(true, $game->playFen('rnbqkb1r/pppp1ppp/5n2/4p3/4P3/5N2/PPPP1PPP/RNBQKB1R w'));
-        $this->assertEquals(true, $game->playFen('rnbqkb1r/pppp1ppp/5n2/4p3/2B1P3/5N2/PPPP1PPP/RNBQK2R b'));
-        $this->assertEquals(true, $game->playFen('rnbqk2r/pppp1ppp/5n2/2b1p3/2B1P3/5N2/PPPP1PPP/RNBQK2R w'));
-        $this->assertEquals(true, $game->playFen('rnbqk2r/pppp1ppp/5n2/2b1p3/2B1P3/5N2/PPPPKPPP/RNBQ3R b'));
-        $this->assertEquals(true, $game->playFen('rnbq3r/ppppkppp/5n2/2b1p3/2B1P3/5N2/PPPPKPPP/RNBQ3R w'));
-        $this->assertEquals(true, $game->playFen('rnbq3r/ppppkppp/5n2/2b1p3/2B1P3/2N2N2/PPPPKPPP/R1BQ3R b'));
+        $this->assertTrue($game->playFen('rnbqkbnr/pppppppp/8/8/4P3/8/PPPP1PPP/RNBQKBNR b'));
+        $this->assertTrue($game->playFen('rnbqkbnr/pppp1ppp/8/4p3/4P3/8/PPPP1PPP/RNBQKBNR w'));
+        $this->assertTrue($game->playFen('rnbqkbnr/pppp1ppp/8/4p3/4P3/5N2/PPPP1PPP/RNBQKB1R b'));
+        $this->assertTrue($game->playFen('rnbqkb1r/pppp1ppp/5n2/4p3/4P3/5N2/PPPP1PPP/RNBQKB1R w'));
+        $this->assertTrue($game->playFen('rnbqkb1r/pppp1ppp/5n2/4p3/2B1P3/5N2/PPPP1PPP/RNBQK2R b'));
+        $this->assertTrue($game->playFen('rnbqk2r/pppp1ppp/5n2/2b1p3/2B1P3/5N2/PPPP1PPP/RNBQK2R w'));
+        $this->assertTrue($game->playFen('rnbqk2r/pppp1ppp/5n2/2b1p3/2B1P3/5N2/PPPPKPPP/RNBQ3R b'));
+        $this->assertTrue($game->playFen('rnbq3r/ppppkppp/5n2/2b1p3/2B1P3/5N2/PPPPKPPP/RNBQ3R w'));
+        $this->assertTrue($game->playFen('rnbq3r/ppppkppp/5n2/2b1p3/2B1P3/2N2N2/PPPPKPPP/R1BQ3R b'));
     }
 
     /**
@@ -143,11 +143,11 @@ class PlayTest extends AbstractUnitTestCase
     public function e4_c5_e5_f5_exf6()
     {
         $game = new Game();
-        $this->assertEquals(true, $game->playFen('rnbqkbnr/pppppppp/8/8/4P3/8/PPPP1PPP/RNBQKBNR b'));
-        $this->assertEquals(true, $game->playFen('rnbqkbnr/pp1ppppp/8/2p5/4P3/8/PPPP1PPP/RNBQKBNR w'));
-        $this->assertEquals(true, $game->playFen('rnbqkbnr/pp1ppppp/8/2p1P3/8/8/PPPP1PPP/RNBQKBNR b'));
-        $this->assertEquals(true, $game->playFen('rnbqkbnr/pp1pp1pp/8/2p1Pp2/8/8/PPPP1PPP/RNBQKBNR w'));
-        $this->assertEquals(true, $game->playFen('rnbqkbnr/pp1pp1pp/5P2/2p5/8/8/PPPP1PPP/RNBQKBNR b'));
+        $this->assertTrue($game->playFen('rnbqkbnr/pppppppp/8/8/4P3/8/PPPP1PPP/RNBQKBNR b'));
+        $this->assertTrue($game->playFen('rnbqkbnr/pp1ppppp/8/2p5/4P3/8/PPPP1PPP/RNBQKBNR w'));
+        $this->assertTrue($game->playFen('rnbqkbnr/pp1ppppp/8/2p1P3/8/8/PPPP1PPP/RNBQKBNR b'));
+        $this->assertTrue($game->playFen('rnbqkbnr/pp1pp1pp/8/2p1Pp2/8/8/PPPP1PPP/RNBQKBNR w'));
+        $this->assertTrue($game->playFen('rnbqkbnr/pp1pp1pp/5P2/2p5/8/8/PPPP1PPP/RNBQKBNR b'));
     }
 
     /**
@@ -156,11 +156,11 @@ class PlayTest extends AbstractUnitTestCase
     public function Nf3_Nf6_d3_d6_Nfd2()
     {
         $game = new Game();
-        $this->assertEquals(true, $game->playFen('rnbqkbnr/pppppppp/8/8/8/5N2/PPPPPPPP/RNBQKB1R b'));
-        $this->assertEquals(true, $game->playFen('rnbqkb1r/pppppppp/5n2/8/8/5N2/PPPPPPPP/RNBQKB1R w'));
-        $this->assertEquals(true, $game->playFen('rnbqkb1r/pppppppp/5n2/8/8/3P1N2/PPP1PPPP/RNBQKB1R b'));
-        $this->assertEquals(true, $game->playFen('rnbqkb1r/ppp1pppp/3p1n2/8/8/3P1N2/PPP1PPPP/RNBQKB1R w'));
-        $this->assertEquals(true, $game->playFen('rnbqkb1r/ppp1pppp/3p1n2/8/8/3P4/PPPNPPPP/RNBQKB1R b'));
+        $this->assertTrue($game->playFen('rnbqkbnr/pppppppp/8/8/8/5N2/PPPPPPPP/RNBQKB1R b'));
+        $this->assertTrue($game->playFen('rnbqkb1r/pppppppp/5n2/8/8/5N2/PPPPPPPP/RNBQKB1R w'));
+        $this->assertTrue($game->playFen('rnbqkb1r/pppppppp/5n2/8/8/3P1N2/PPP1PPPP/RNBQKB1R b'));
+        $this->assertTrue($game->playFen('rnbqkb1r/ppp1pppp/3p1n2/8/8/3P1N2/PPP1PPPP/RNBQKB1R w'));
+        $this->assertTrue($game->playFen('rnbqkb1r/ppp1pppp/3p1n2/8/8/3P4/PPPNPPPP/RNBQKB1R b'));
     }
 
     /**
@@ -169,15 +169,15 @@ class PlayTest extends AbstractUnitTestCase
     public function a4_h5_a5_h4_a6_h3_axb7_hxg2()
     {
         $game = new Game();
-        $this->assertEquals(true, $game->playFen('rnbqkbnr/pppppppp/8/8/P7/8/1PPPPPPP/RNBQKBNR b'));
-        $this->assertEquals(true, $game->playFen('rnbqkbnr/ppppppp1/8/7p/P7/8/1PPPPPPP/RNBQKBNR w'));
-        $this->assertEquals(true, $game->playFen('rnbqkbnr/ppppppp1/8/P6p/8/8/1PPPPPPP/RNBQKBNR b'));
-        $this->assertEquals(true, $game->playFen('rnbqkbnr/ppppppp1/8/P7/7p/8/1PPPPPPP/RNBQKBNR w'));
-        $this->assertEquals(true, $game->playFen('rnbqkbnr/ppppppp1/P7/8/7p/8/1PPPPPPP/RNBQKBNR b'));
-        $this->assertEquals(true, $game->playFen('rnbqkbnr/ppppppp1/P7/8/8/7p/1PPPPPPP/RNBQKBNR w'));
-        $this->assertEquals(true, $game->playFen('rnbqkbnr/pPppppp1/8/8/8/7p/1PPPPPPP/RNBQKBNR b'));
-        $this->assertEquals(true, $game->playFen('rnbqkbnr/pPppppp1/8/8/8/8/1PPPPPpP/RNBQKBNR w'));
-        $this->assertEquals(true, $game->playFen('Qnbqkbnr/p1ppppp1/8/8/8/8/1PPPPPpP/RNBQKBNR b'));
+        $this->assertTrue($game->playFen('rnbqkbnr/pppppppp/8/8/P7/8/1PPPPPPP/RNBQKBNR b'));
+        $this->assertTrue($game->playFen('rnbqkbnr/ppppppp1/8/7p/P7/8/1PPPPPPP/RNBQKBNR w'));
+        $this->assertTrue($game->playFen('rnbqkbnr/ppppppp1/8/P6p/8/8/1PPPPPPP/RNBQKBNR b'));
+        $this->assertTrue($game->playFen('rnbqkbnr/ppppppp1/8/P7/7p/8/1PPPPPPP/RNBQKBNR w'));
+        $this->assertTrue($game->playFen('rnbqkbnr/ppppppp1/P7/8/7p/8/1PPPPPPP/RNBQKBNR b'));
+        $this->assertTrue($game->playFen('rnbqkbnr/ppppppp1/P7/8/8/7p/1PPPPPPP/RNBQKBNR w'));
+        $this->assertTrue($game->playFen('rnbqkbnr/pPppppp1/8/8/8/7p/1PPPPPPP/RNBQKBNR b'));
+        $this->assertTrue($game->playFen('rnbqkbnr/pPppppp1/8/8/8/8/1PPPPPpP/RNBQKBNR w'));
+        $this->assertTrue($game->playFen('Qnbqkbnr/p1ppppp1/8/8/8/8/1PPPPPpP/RNBQKBNR b'));
     }
 
     /**
@@ -186,11 +186,11 @@ class PlayTest extends AbstractUnitTestCase
     public function e4_d5_exd5_e5_dxe6()
     {
         $game = new Game();
-        $this->assertEquals(true, $game->playFen('rnbqkbnr/pppppppp/8/8/4P3/8/PPPP1PPP/RNBQKBNR b'));
-        $this->assertEquals(true, $game->playFen('rnbqkbnr/ppp1pppp/8/3p4/4P3/8/PPPP1PPP/RNBQKBNR w'));
-        $this->assertEquals(true, $game->playFen('rnbqkbnr/ppp1pppp/8/3P4/8/8/PPPP1PPP/RNBQKBNR b'));
-        $this->assertEquals(true, $game->playFen('rnbqkbnr/ppp2ppp/8/3Pp3/8/8/PPPP1PPP/RNBQKBNR w'));
-        $this->assertEquals(true, $game->playFen('rnbqkbnr/ppp2ppp/4P3/8/8/8/PPPP1PPP/RNBQKBNR b'));
+        $this->assertTrue($game->playFen('rnbqkbnr/pppppppp/8/8/4P3/8/PPPP1PPP/RNBQKBNR b'));
+        $this->assertTrue($game->playFen('rnbqkbnr/ppp1pppp/8/3p4/4P3/8/PPPP1PPP/RNBQKBNR w'));
+        $this->assertTrue($game->playFen('rnbqkbnr/ppp1pppp/8/3P4/8/8/PPPP1PPP/RNBQKBNR b'));
+        $this->assertTrue($game->playFen('rnbqkbnr/ppp2ppp/8/3Pp3/8/8/PPPP1PPP/RNBQKBNR w'));
+        $this->assertTrue($game->playFen('rnbqkbnr/ppp2ppp/4P3/8/8/8/PPPP1PPP/RNBQKBNR b'));
     }
 
     /**
@@ -199,12 +199,12 @@ class PlayTest extends AbstractUnitTestCase
     public function e4_d5_exd5_e5_then_get_piece()
     {
         $game = new Game();
-        $this->assertEquals(true, $game->playFen('rnbqkbnr/pppppppp/8/8/4P3/8/PPPP1PPP/RNBQKBNR b'));
-        $this->assertEquals(true, $game->playFen('rnbqkbnr/ppp1pppp/8/3p4/4P3/8/PPPP1PPP/RNBQKBNR w'));
-        $this->assertEquals(true, $game->playFen('rnbqkbnr/ppp1pppp/8/3P4/8/8/PPPP1PPP/RNBQKBNR b'));
-        $this->assertEquals(true, $game->playFen('rnbqkbnr/ppp2ppp/8/3Pp3/8/8/PPPP1PPP/RNBQKBNR w'));
+        $this->assertTrue($game->playFen('rnbqkbnr/pppppppp/8/8/4P3/8/PPPP1PPP/RNBQKBNR b'));
+        $this->assertTrue($game->playFen('rnbqkbnr/ppp1pppp/8/3p4/4P3/8/PPPP1PPP/RNBQKBNR w'));
+        $this->assertTrue($game->playFen('rnbqkbnr/ppp1pppp/8/3P4/8/8/PPPP1PPP/RNBQKBNR b'));
+        $this->assertTrue($game->playFen('rnbqkbnr/ppp2ppp/8/3Pp3/8/8/PPPP1PPP/RNBQKBNR w'));
 
-        $this->assertEquals('P', $game->piece('d5')->identity);
+        $this->assertSame('P', $game->piece('d5')->identity);
     }
 
     /**
@@ -213,13 +213,13 @@ class PlayTest extends AbstractUnitTestCase
     public function e4_d5_Bb5()
     {
         $game = new Game();
-        $this->assertEquals(true, $game->playFen('rnbqkbnr/pppppppp/8/8/4P3/8/PPPP1PPP/RNBQKBNR b'));
-        $this->assertEquals(true, $game->playFen('rnbqkbnr/ppp1pppp/8/3p4/4P3/8/PPPP1PPP/RNBQKBNR w'));
-        $this->assertEquals(true, $game->playFen('rnbqkbnr/ppp1pppp/8/1B1p4/4P3/8/PPPP1PPP/RNBQK1NR b'));
+        $this->assertTrue($game->playFen('rnbqkbnr/pppppppp/8/8/4P3/8/PPPP1PPP/RNBQKBNR b'));
+        $this->assertTrue($game->playFen('rnbqkbnr/ppp1pppp/8/3p4/4P3/8/PPPP1PPP/RNBQKBNR w'));
+        $this->assertTrue($game->playFen('rnbqkbnr/ppp1pppp/8/1B1p4/4P3/8/PPPP1PPP/RNBQK1NR b'));
 
         $expected = '1.e4 d5 2.Bb5+';
 
-        $this->assertEquals($expected, $game->movetext());
+        $this->assertSame($expected, $game->movetext());
     }
 
     /**
@@ -228,14 +228,14 @@ class PlayTest extends AbstractUnitTestCase
     public function f4_e5_g4_Qh4()
     {
         $game = new Game();
-        $this->assertEquals(true, $game->playFen('rnbqkbnr/pppppppp/8/8/5P2/8/PPPPP1PP/RNBQKBNR b'));
-        $this->assertEquals(true, $game->playFen('rnbqkbnr/pppp1ppp/8/4p3/5P2/8/PPPPP1PP/RNBQKBNR w'));
-        $this->assertEquals(true, $game->playFen('rnbqkbnr/pppp1ppp/8/4p3/5PP1/8/PPPPP2P/RNBQKBNR b'));
-        $this->assertEquals(true, $game->playFen('rnb1kbnr/pppp1ppp/8/4p3/5PPq/8/PPPPP2P/RNBQKBNR w'));
+        $this->assertTrue($game->playFen('rnbqkbnr/pppppppp/8/8/5P2/8/PPPPP1PP/RNBQKBNR b'));
+        $this->assertTrue($game->playFen('rnbqkbnr/pppp1ppp/8/4p3/5P2/8/PPPPP1PP/RNBQKBNR w'));
+        $this->assertTrue($game->playFen('rnbqkbnr/pppp1ppp/8/4p3/5PP1/8/PPPPP2P/RNBQKBNR b'));
+        $this->assertTrue($game->playFen('rnb1kbnr/pppp1ppp/8/4p3/5PPq/8/PPPPP2P/RNBQKBNR w'));
 
         $expected = '1.f4 e5 2.g4 Qh4#';
 
-        $this->assertEquals($expected, $game->movetext());
+        $this->assertSame($expected, $game->movetext());
     }
 
     /**
@@ -244,14 +244,14 @@ class PlayTest extends AbstractUnitTestCase
     public function e4_c5_Nf3_d6_d4_cxd4_Nxd4_Nf6_then_get_piece()
     {
         $game = new Game();
-        $this->assertEquals(true, $game->playFen('rnbqkbnr/pppppppp/8/8/4P3/8/PPPP1PPP/RNBQKBNR b'));
-        $this->assertEquals(true, $game->playFen('rnbqkbnr/pp1ppppp/8/2p5/4P3/8/PPPP1PPP/RNBQKBNR w'));
-        $this->assertEquals(true, $game->playFen('rnbqkbnr/pp1ppppp/8/2p5/4P3/5N2/PPPP1PPP/RNBQKB1R b'));
-        $this->assertEquals(true, $game->playFen('rnbqkbnr/pp2pppp/3p4/2p5/4P3/5N2/PPPP1PPP/RNBQKB1R w'));
-        $this->assertEquals(true, $game->playFen('rnbqkbnr/pp2pppp/3p4/2p5/3PP3/5N2/PPP2PPP/RNBQKB1R b'));
-        $this->assertEquals(true, $game->playFen('rnbqkbnr/pp2pppp/3p4/8/3pP3/5N2/PPP2PPP/RNBQKB1R w'));
-        $this->assertEquals(true, $game->playFen('rnbqkbnr/pp2pppp/3p4/8/3NP3/8/PPP2PPP/RNBQKB1R b'));
-        $this->assertEquals(true, $game->playFen('rnbqkb1r/pp2pppp/3p1n2/8/3NP3/8/PPP2PPP/RNBQKB1R w'));
+        $this->assertTrue($game->playFen('rnbqkbnr/pppppppp/8/8/4P3/8/PPPP1PPP/RNBQKBNR b'));
+        $this->assertTrue($game->playFen('rnbqkbnr/pp1ppppp/8/2p5/4P3/8/PPPP1PPP/RNBQKBNR w'));
+        $this->assertTrue($game->playFen('rnbqkbnr/pp1ppppp/8/2p5/4P3/5N2/PPPP1PPP/RNBQKB1R b'));
+        $this->assertTrue($game->playFen('rnbqkbnr/pp2pppp/3p4/2p5/4P3/5N2/PPPP1PPP/RNBQKB1R w'));
+        $this->assertTrue($game->playFen('rnbqkbnr/pp2pppp/3p4/2p5/3PP3/5N2/PPP2PPP/RNBQKB1R b'));
+        $this->assertTrue($game->playFen('rnbqkbnr/pp2pppp/3p4/8/3pP3/5N2/PPP2PPP/RNBQKB1R w'));
+        $this->assertTrue($game->playFen('rnbqkbnr/pp2pppp/3p4/8/3NP3/8/PPP2PPP/RNBQKB1R b'));
+        $this->assertTrue($game->playFen('rnbqkb1r/pp2pppp/3p1n2/8/3NP3/8/PPP2PPP/RNBQKB1R w'));
 
         $this->assertNotEmpty($game->piece('b1')->moves);
     }
@@ -262,15 +262,15 @@ class PlayTest extends AbstractUnitTestCase
     public function e4_c5_Nf3_d6_d4_cxd4_Nxd4_Nf6_Nc3()
     {
         $game = new Game();
-        $this->assertEquals(true, $game->playFen('rnbqkbnr/pppppppp/8/8/4P3/8/PPPP1PPP/RNBQKBNR b'));
-        $this->assertEquals(true, $game->playFen('rnbqkbnr/pp1ppppp/8/2p5/4P3/8/PPPP1PPP/RNBQKBNR w'));
-        $this->assertEquals(true, $game->playFen('rnbqkbnr/pp1ppppp/8/2p5/4P3/5N2/PPPP1PPP/RNBQKB1R b'));
-        $this->assertEquals(true, $game->playFen('rnbqkbnr/pp2pppp/3p4/2p5/4P3/5N2/PPPP1PPP/RNBQKB1R w'));
-        $this->assertEquals(true, $game->playFen('rnbqkbnr/pp2pppp/3p4/2p5/3PP3/5N2/PPP2PPP/RNBQKB1R b'));
-        $this->assertEquals(true, $game->playFen('rnbqkbnr/pp2pppp/3p4/8/3pP3/5N2/PPP2PPP/RNBQKB1R w'));
-        $this->assertEquals(true, $game->playFen('rnbqkbnr/pp2pppp/3p4/8/3NP3/8/PPP2PPP/RNBQKB1R b'));
-        $this->assertEquals(true, $game->playFen('rnbqkb1r/pp2pppp/3p1n2/8/3NP3/8/PPP2PPP/RNBQKB1R w'));
-        $this->assertEquals(true, $game->playFen('rnbqkb1r/pp2pppp/3p1n2/8/3NP3/2N5/PPP2PPP/R1BQKB1R b'));
+        $this->assertTrue($game->playFen('rnbqkbnr/pppppppp/8/8/4P3/8/PPPP1PPP/RNBQKBNR b'));
+        $this->assertTrue($game->playFen('rnbqkbnr/pp1ppppp/8/2p5/4P3/8/PPPP1PPP/RNBQKBNR w'));
+        $this->assertTrue($game->playFen('rnbqkbnr/pp1ppppp/8/2p5/4P3/5N2/PPPP1PPP/RNBQKB1R b'));
+        $this->assertTrue($game->playFen('rnbqkbnr/pp2pppp/3p4/2p5/4P3/5N2/PPPP1PPP/RNBQKB1R w'));
+        $this->assertTrue($game->playFen('rnbqkbnr/pp2pppp/3p4/2p5/3PP3/5N2/PPP2PPP/RNBQKB1R b'));
+        $this->assertTrue($game->playFen('rnbqkbnr/pp2pppp/3p4/8/3pP3/5N2/PPP2PPP/RNBQKB1R w'));
+        $this->assertTrue($game->playFen('rnbqkbnr/pp2pppp/3p4/8/3NP3/8/PPP2PPP/RNBQKB1R b'));
+        $this->assertTrue($game->playFen('rnbqkb1r/pp2pppp/3p1n2/8/3NP3/8/PPP2PPP/RNBQKB1R w'));
+        $this->assertTrue($game->playFen('rnbqkb1r/pp2pppp/3p1n2/8/3NP3/2N5/PPP2PPP/R1BQKB1R b'));
     }
 
     /**
@@ -292,7 +292,7 @@ class PlayTest extends AbstractUnitTestCase
                     " .  P  .  .  .  P  P  P \n" .
                     " .  .  R  Q  .  R  .  K \n";
 
-        $this->assertEquals($expected, $ascii);
+        $this->assertSame($expected, $ascii);
     }
 
     /**
@@ -315,7 +315,7 @@ class PlayTest extends AbstractUnitTestCase
                     " .  P  .  .  .  P  P  P \n" .
                     " .  .  R  .  .  R  .  K \n";
 
-        $this->assertEquals($expected, $ascii);
+        $this->assertSame($expected, $ascii);
     }
 
     /**
@@ -338,7 +338,7 @@ class PlayTest extends AbstractUnitTestCase
                     " .  P  .  .  .  P  P  P \n" .
                     " .  .  R  .  .  R  .  K \n";
 
-        $this->assertEquals($expected, $ascii);
+        $this->assertSame($expected, $ascii);
     }
 
     /**
@@ -362,7 +362,7 @@ class PlayTest extends AbstractUnitTestCase
                     " .  P  .  .  .  P  P  P \n" .
                     " .  .  R  .  .  R  .  K \n";
 
-        $this->assertEquals($expected, $ascii);
+        $this->assertSame($expected, $ascii);
     }
 
     /**
@@ -392,27 +392,27 @@ class PlayTest extends AbstractUnitTestCase
     public function e4_e5_Nf3_Nc6_Bb5_a6_Ba4_b5_Bb3_Bb7_a4_Nf6_Nc3_g6_Qe2_d6_d3_Be7_Bg5_Qd7_O_O_O()
     {
         $game = new Game();
-        $this->assertEquals(true, $game->playFen('rnbqkbnr/pppppppp/8/8/4P3/8/PPPP1PPP/RNBQKBNR b'));
-        $this->assertEquals(true, $game->playFen('rnbqkbnr/pppp1ppp/8/4p3/4P3/8/PPPP1PPP/RNBQKBNR w'));
-        $this->assertEquals(true, $game->playFen('rnbqkbnr/pppp1ppp/8/4p3/4P3/5N2/PPPP1PPP/RNBQKB1R b'));
-        $this->assertEquals(true, $game->playFen('r1bqkbnr/pppp1ppp/2n5/4p3/4P3/5N2/PPPP1PPP/RNBQKB1R w'));
-        $this->assertEquals(true, $game->playFen('r1bqkbnr/pppp1ppp/2n5/1B2p3/4P3/5N2/PPPP1PPP/RNBQK2R b'));
-        $this->assertEquals(true, $game->playFen('r1bqkbnr/1ppp1ppp/p1n5/1B2p3/4P3/5N2/PPPP1PPP/RNBQK2R w'));
-        $this->assertEquals(true, $game->playFen('r1bqkbnr/1ppp1ppp/p1n5/4p3/B3P3/5N2/PPPP1PPP/RNBQK2R b'));
-        $this->assertEquals(true, $game->playFen('r1bqkbnr/2pp1ppp/p1n5/1p2p3/B3P3/5N2/PPPP1PPP/RNBQK2R w'));
-        $this->assertEquals(true, $game->playFen('r1bqkbnr/2pp1ppp/p1n5/1p2p3/4P3/1B3N2/PPPP1PPP/RNBQK2R b'));
-        $this->assertEquals(true, $game->playFen('r2qkbnr/1bpp1ppp/p1n5/1p2p3/4P3/1B3N2/PPPP1PPP/RNBQK2R w'));
-        $this->assertEquals(true, $game->playFen('r2qkbnr/1bpp1ppp/p1n5/1p2p3/P3P3/1B3N2/1PPP1PPP/RNBQK2R b'));
-        $this->assertEquals(true, $game->playFen('r2qkb1r/1bpp1ppp/p1n2n2/1p2p3/P3P3/1B3N2/1PPP1PPP/RNBQK2R w'));
-        $this->assertEquals(true, $game->playFen('r2qkb1r/1bpp1ppp/p1n2n2/1p2p3/P3P3/1BN2N2/1PPP1PPP/R1BQK2R b'));
-        $this->assertEquals(true, $game->playFen('r2qkb1r/1bpp1p1p/p1n2np1/1p2p3/P3P3/1BN2N2/1PPP1PPP/R1BQK2R w'));
-        $this->assertEquals(true, $game->playFen('r2qkb1r/1bpp1p1p/p1n2np1/1p2p3/P3P3/1BN2N2/1PPPQPPP/R1B1K2R b'));
-        $this->assertEquals(true, $game->playFen('r2qkb1r/1bp2p1p/p1np1np1/1p2p3/P3P3/1BN2N2/1PPPQPPP/R1B1K2R w'));
-        $this->assertEquals(true, $game->playFen('r2qkb1r/1bp2p1p/p1np1np1/1p2p3/P3P3/1BNP1N2/1PP1QPPP/R1B1K2R b'));
-        $this->assertEquals(true, $game->playFen('r2qk2r/1bp1bp1p/p1np1np1/1p2p3/P3P3/1BNP1N2/1PP1QPPP/R1B1K2R w'));
-        $this->assertEquals(true, $game->playFen('r2qk2r/1bp1bp1p/p1np1np1/1p2p1B1/P3P3/1BNP1N2/1PP1QPPP/R3K2R b'));
-        $this->assertEquals(true, $game->playFen('r3k2r/1bpqbp1p/p1np1np1/1p2p1B1/P3P3/1BNP1N2/1PP1QPPP/R3K2R w'));
-        $this->assertEquals('O-O-O', $game->playFen('r3k2r/1bpqbp1p/p1np1np1/1p2p1B1/P3P3/1BNP1N2/1PP1QPPP/R1K4R b'));
+        $this->assertTrue($game->playFen('rnbqkbnr/pppppppp/8/8/4P3/8/PPPP1PPP/RNBQKBNR b'));
+        $this->assertTrue($game->playFen('rnbqkbnr/pppp1ppp/8/4p3/4P3/8/PPPP1PPP/RNBQKBNR w'));
+        $this->assertTrue($game->playFen('rnbqkbnr/pppp1ppp/8/4p3/4P3/5N2/PPPP1PPP/RNBQKB1R b'));
+        $this->assertTrue($game->playFen('r1bqkbnr/pppp1ppp/2n5/4p3/4P3/5N2/PPPP1PPP/RNBQKB1R w'));
+        $this->assertTrue($game->playFen('r1bqkbnr/pppp1ppp/2n5/1B2p3/4P3/5N2/PPPP1PPP/RNBQK2R b'));
+        $this->assertTrue($game->playFen('r1bqkbnr/1ppp1ppp/p1n5/1B2p3/4P3/5N2/PPPP1PPP/RNBQK2R w'));
+        $this->assertTrue($game->playFen('r1bqkbnr/1ppp1ppp/p1n5/4p3/B3P3/5N2/PPPP1PPP/RNBQK2R b'));
+        $this->assertTrue($game->playFen('r1bqkbnr/2pp1ppp/p1n5/1p2p3/B3P3/5N2/PPPP1PPP/RNBQK2R w'));
+        $this->assertTrue($game->playFen('r1bqkbnr/2pp1ppp/p1n5/1p2p3/4P3/1B3N2/PPPP1PPP/RNBQK2R b'));
+        $this->assertTrue($game->playFen('r2qkbnr/1bpp1ppp/p1n5/1p2p3/4P3/1B3N2/PPPP1PPP/RNBQK2R w'));
+        $this->assertTrue($game->playFen('r2qkbnr/1bpp1ppp/p1n5/1p2p3/P3P3/1B3N2/1PPP1PPP/RNBQK2R b'));
+        $this->assertTrue($game->playFen('r2qkb1r/1bpp1ppp/p1n2n2/1p2p3/P3P3/1B3N2/1PPP1PPP/RNBQK2R w'));
+        $this->assertTrue($game->playFen('r2qkb1r/1bpp1ppp/p1n2n2/1p2p3/P3P3/1BN2N2/1PPP1PPP/R1BQK2R b'));
+        $this->assertTrue($game->playFen('r2qkb1r/1bpp1p1p/p1n2np1/1p2p3/P3P3/1BN2N2/1PPP1PPP/R1BQK2R w'));
+        $this->assertTrue($game->playFen('r2qkb1r/1bpp1p1p/p1n2np1/1p2p3/P3P3/1BN2N2/1PPPQPPP/R1B1K2R b'));
+        $this->assertTrue($game->playFen('r2qkb1r/1bp2p1p/p1np1np1/1p2p3/P3P3/1BN2N2/1PPPQPPP/R1B1K2R w'));
+        $this->assertTrue($game->playFen('r2qkb1r/1bp2p1p/p1np1np1/1p2p3/P3P3/1BNP1N2/1PP1QPPP/R1B1K2R b'));
+        $this->assertTrue($game->playFen('r2qk2r/1bp1bp1p/p1np1np1/1p2p3/P3P3/1BNP1N2/1PP1QPPP/R1B1K2R w'));
+        $this->assertTrue($game->playFen('r2qk2r/1bp1bp1p/p1np1np1/1p2p1B1/P3P3/1BNP1N2/1PP1QPPP/R3K2R b'));
+        $this->assertTrue($game->playFen('r3k2r/1bpqbp1p/p1np1np1/1p2p1B1/P3P3/1BNP1N2/1PP1QPPP/R3K2R w'));
+        $this->assertSame('O-O-O', $game->playFen('r3k2r/1bpqbp1p/p1np1np1/1p2p1B1/P3P3/1BNP1N2/1PP1QPPP/R1K4R b'));
 
         $ascii = $game->ascii();
 
@@ -425,7 +425,7 @@ class PlayTest extends AbstractUnitTestCase
                     " .  P  P  .  Q  P  P  P \n" .
                     " .  .  K  R  .  .  .  R \n";
 
-        $this->assertEquals($expected, $ascii);
+        $this->assertSame($expected, $ascii);
     }
 
     /**
@@ -434,28 +434,28 @@ class PlayTest extends AbstractUnitTestCase
     public function e4_e5_Nf3_Nc6_Bb5_a6_Ba4_b5_Bb3_Bb7_a4_Nf6_Nc3_g6_Qe2_d6_d3_Be7_Bg5_Qd7_O_O_O_O_O()
     {
         $game = new Game();
-        $this->assertEquals(true, $game->playFen('rnbqkbnr/pppppppp/8/8/4P3/8/PPPP1PPP/RNBQKBNR b'));
-        $this->assertEquals(true, $game->playFen('rnbqkbnr/pppp1ppp/8/4p3/4P3/8/PPPP1PPP/RNBQKBNR w'));
-        $this->assertEquals(true, $game->playFen('rnbqkbnr/pppp1ppp/8/4p3/4P3/5N2/PPPP1PPP/RNBQKB1R b'));
-        $this->assertEquals(true, $game->playFen('r1bqkbnr/pppp1ppp/2n5/4p3/4P3/5N2/PPPP1PPP/RNBQKB1R w'));
-        $this->assertEquals(true, $game->playFen('r1bqkbnr/pppp1ppp/2n5/1B2p3/4P3/5N2/PPPP1PPP/RNBQK2R b'));
-        $this->assertEquals(true, $game->playFen('r1bqkbnr/1ppp1ppp/p1n5/1B2p3/4P3/5N2/PPPP1PPP/RNBQK2R w'));
-        $this->assertEquals(true, $game->playFen('r1bqkbnr/1ppp1ppp/p1n5/4p3/B3P3/5N2/PPPP1PPP/RNBQK2R b'));
-        $this->assertEquals(true, $game->playFen('r1bqkbnr/2pp1ppp/p1n5/1p2p3/B3P3/5N2/PPPP1PPP/RNBQK2R w'));
-        $this->assertEquals(true, $game->playFen('r1bqkbnr/2pp1ppp/p1n5/1p2p3/4P3/1B3N2/PPPP1PPP/RNBQK2R b'));
-        $this->assertEquals(true, $game->playFen('r2qkbnr/1bpp1ppp/p1n5/1p2p3/4P3/1B3N2/PPPP1PPP/RNBQK2R w'));
-        $this->assertEquals(true, $game->playFen('r2qkbnr/1bpp1ppp/p1n5/1p2p3/P3P3/1B3N2/1PPP1PPP/RNBQK2R b'));
-        $this->assertEquals(true, $game->playFen('r2qkb1r/1bpp1ppp/p1n2n2/1p2p3/P3P3/1B3N2/1PPP1PPP/RNBQK2R w'));
-        $this->assertEquals(true, $game->playFen('r2qkb1r/1bpp1ppp/p1n2n2/1p2p3/P3P3/1BN2N2/1PPP1PPP/R1BQK2R b'));
-        $this->assertEquals(true, $game->playFen('r2qkb1r/1bpp1p1p/p1n2np1/1p2p3/P3P3/1BN2N2/1PPP1PPP/R1BQK2R w'));
-        $this->assertEquals(true, $game->playFen('r2qkb1r/1bpp1p1p/p1n2np1/1p2p3/P3P3/1BN2N2/1PPPQPPP/R1B1K2R b'));
-        $this->assertEquals(true, $game->playFen('r2qkb1r/1bp2p1p/p1np1np1/1p2p3/P3P3/1BN2N2/1PPPQPPP/R1B1K2R w'));
-        $this->assertEquals(true, $game->playFen('r2qkb1r/1bp2p1p/p1np1np1/1p2p3/P3P3/1BNP1N2/1PP1QPPP/R1B1K2R b'));
-        $this->assertEquals(true, $game->playFen('r2qk2r/1bp1bp1p/p1np1np1/1p2p3/P3P3/1BNP1N2/1PP1QPPP/R1B1K2R w'));
-        $this->assertEquals(true, $game->playFen('r2qk2r/1bp1bp1p/p1np1np1/1p2p1B1/P3P3/1BNP1N2/1PP1QPPP/R3K2R b'));
-        $this->assertEquals(true, $game->playFen('r3k2r/1bpqbp1p/p1np1np1/1p2p1B1/P3P3/1BNP1N2/1PP1QPPP/R3K2R w'));
-        $this->assertEquals('O-O-O', $game->playFen('r3k2r/1bpqbp1p/p1np1np1/1p2p1B1/P3P3/1BNP1N2/1PP1QPPP/R1K4R b'));
-        $this->assertEquals('O-O', $game->playFen('r5kr/1bpqbp1p/p1np1np1/1p2p1B1/P3P3/1BNP1N2/1PP1QPPP/2KR3R w'));
+        $this->assertTrue($game->playFen('rnbqkbnr/pppppppp/8/8/4P3/8/PPPP1PPP/RNBQKBNR b'));
+        $this->assertTrue($game->playFen('rnbqkbnr/pppp1ppp/8/4p3/4P3/8/PPPP1PPP/RNBQKBNR w'));
+        $this->assertTrue($game->playFen('rnbqkbnr/pppp1ppp/8/4p3/4P3/5N2/PPPP1PPP/RNBQKB1R b'));
+        $this->assertTrue($game->playFen('r1bqkbnr/pppp1ppp/2n5/4p3/4P3/5N2/PPPP1PPP/RNBQKB1R w'));
+        $this->assertTrue($game->playFen('r1bqkbnr/pppp1ppp/2n5/1B2p3/4P3/5N2/PPPP1PPP/RNBQK2R b'));
+        $this->assertTrue($game->playFen('r1bqkbnr/1ppp1ppp/p1n5/1B2p3/4P3/5N2/PPPP1PPP/RNBQK2R w'));
+        $this->assertTrue($game->playFen('r1bqkbnr/1ppp1ppp/p1n5/4p3/B3P3/5N2/PPPP1PPP/RNBQK2R b'));
+        $this->assertTrue($game->playFen('r1bqkbnr/2pp1ppp/p1n5/1p2p3/B3P3/5N2/PPPP1PPP/RNBQK2R w'));
+        $this->assertTrue($game->playFen('r1bqkbnr/2pp1ppp/p1n5/1p2p3/4P3/1B3N2/PPPP1PPP/RNBQK2R b'));
+        $this->assertTrue($game->playFen('r2qkbnr/1bpp1ppp/p1n5/1p2p3/4P3/1B3N2/PPPP1PPP/RNBQK2R w'));
+        $this->assertTrue($game->playFen('r2qkbnr/1bpp1ppp/p1n5/1p2p3/P3P3/1B3N2/1PPP1PPP/RNBQK2R b'));
+        $this->assertTrue($game->playFen('r2qkb1r/1bpp1ppp/p1n2n2/1p2p3/P3P3/1B3N2/1PPP1PPP/RNBQK2R w'));
+        $this->assertTrue($game->playFen('r2qkb1r/1bpp1ppp/p1n2n2/1p2p3/P3P3/1BN2N2/1PPP1PPP/R1BQK2R b'));
+        $this->assertTrue($game->playFen('r2qkb1r/1bpp1p1p/p1n2np1/1p2p3/P3P3/1BN2N2/1PPP1PPP/R1BQK2R w'));
+        $this->assertTrue($game->playFen('r2qkb1r/1bpp1p1p/p1n2np1/1p2p3/P3P3/1BN2N2/1PPPQPPP/R1B1K2R b'));
+        $this->assertTrue($game->playFen('r2qkb1r/1bp2p1p/p1np1np1/1p2p3/P3P3/1BN2N2/1PPPQPPP/R1B1K2R w'));
+        $this->assertTrue($game->playFen('r2qkb1r/1bp2p1p/p1np1np1/1p2p3/P3P3/1BNP1N2/1PP1QPPP/R1B1K2R b'));
+        $this->assertTrue($game->playFen('r2qk2r/1bp1bp1p/p1np1np1/1p2p3/P3P3/1BNP1N2/1PP1QPPP/R1B1K2R w'));
+        $this->assertTrue($game->playFen('r2qk2r/1bp1bp1p/p1np1np1/1p2p1B1/P3P3/1BNP1N2/1PP1QPPP/R3K2R b'));
+        $this->assertTrue($game->playFen('r3k2r/1bpqbp1p/p1np1np1/1p2p1B1/P3P3/1BNP1N2/1PP1QPPP/R3K2R w'));
+        $this->assertSame('O-O-O', $game->playFen('r3k2r/1bpqbp1p/p1np1np1/1p2p1B1/P3P3/1BNP1N2/1PP1QPPP/R1K4R b'));
+        $this->assertSame('O-O', $game->playFen('r5kr/1bpqbp1p/p1np1np1/1p2p1B1/P3P3/1BNP1N2/1PP1QPPP/2KR3R w'));
 
         $ascii = $game->ascii();
 
@@ -468,7 +468,7 @@ class PlayTest extends AbstractUnitTestCase
                     " .  P  P  .  Q  P  P  P \n" .
                     " .  .  K  R  .  .  .  R \n";
 
-        $this->assertEquals($expected, $ascii);
+        $this->assertSame($expected, $ascii);
     }
 
     /**
@@ -477,23 +477,23 @@ class PlayTest extends AbstractUnitTestCase
     public function e4_e5_Nf3_Nc6_Bc4_h6_h4_g5_hxg5_hxg5_Rxh8_Bg7_d3_Bxh8_Qe2_Nge7_c3()
     {
         $game = new Game();
-        $this->assertEquals(true, $game->playFen('rnbqkbnr/pppppppp/8/8/4P3/8/PPPP1PPP/RNBQKBNR b'));
-        $this->assertEquals(true, $game->playFen('rnbqkbnr/pppp1ppp/8/4p3/4P3/8/PPPP1PPP/RNBQKBNR w'));
-        $this->assertEquals(true, $game->playFen('rnbqkbnr/pppp1ppp/8/4p3/4P3/5N2/PPPP1PPP/RNBQKB1R b'));
-        $this->assertEquals(true, $game->playFen('r1bqkbnr/pppp1ppp/2n5/4p3/4P3/5N2/PPPP1PPP/RNBQKB1R w'));
-        $this->assertEquals(true, $game->playFen('r1bqkbnr/pppp1ppp/2n5/4p3/2B1P3/5N2/PPPP1PPP/RNBQK2R b'));
-        $this->assertEquals(true, $game->playFen('r1bqkbnr/pppp1pp1/2n4p/4p3/2B1P3/5N2/PPPP1PPP/RNBQK2R w'));
-        $this->assertEquals(true, $game->playFen('r1bqkbnr/pppp1pp1/2n4p/4p3/2B1P2P/5N2/PPPP1PP1/RNBQK2R b'));
-        $this->assertEquals(true, $game->playFen('r1bqkbnr/pppp1p2/2n4p/4p1p1/2B1P2P/5N2/PPPP1PP1/RNBQK2R w'));
-        $this->assertEquals(true, $game->playFen('r1bqkbnr/pppp1p2/2n4p/4p1P1/2B1P3/5N2/PPPP1PP1/RNBQK2R b'));
-        $this->assertEquals(true, $game->playFen('r1bqkbnr/pppp1p2/2n5/4p1p1/2B1P3/5N2/PPPP1PP1/RNBQK2R w'));
-        $this->assertEquals(true, $game->playFen('r1bqkbnR/pppp1p2/2n5/4p1p1/2B1P3/5N2/PPPP1PP1/RNBQK3 b'));
-        $this->assertEquals(true, $game->playFen('r1bqk1nR/pppp1pb1/2n5/4p1p1/2B1P3/5N2/PPPP1PP1/RNBQK3 w'));
-        $this->assertEquals(true, $game->playFen('r1bqk1nR/pppp1pb1/2n5/4p1p1/2B1P3/3P1N2/PPP2PP1/RNBQK3 b'));
-        $this->assertEquals(true, $game->playFen('r1bqk1nb/pppp1p2/2n5/4p1p1/2B1P3/3P1N2/PPP2PP1/RNBQK3 w'));
-        $this->assertEquals(true, $game->playFen('r1bqk1nb/pppp1p2/2n5/4p1p1/2B1P3/3P1N2/PPP1QPP1/RNB1K3 b'));
-        $this->assertEquals(true, $game->playFen('r1bqk2b/ppppnp2/2n5/4p1p1/2B1P3/3P1N2/PPP1QPP1/RNB1K3 w'));
-        $this->assertEquals(true, $game->playFen('r1bqk2b/ppppnp2/2n5/4p1p1/2B1P3/2PP1N2/PP2QPP1/RNB1K3 b'));
+        $this->assertTrue($game->playFen('rnbqkbnr/pppppppp/8/8/4P3/8/PPPP1PPP/RNBQKBNR b'));
+        $this->assertTrue($game->playFen('rnbqkbnr/pppp1ppp/8/4p3/4P3/8/PPPP1PPP/RNBQKBNR w'));
+        $this->assertTrue($game->playFen('rnbqkbnr/pppp1ppp/8/4p3/4P3/5N2/PPPP1PPP/RNBQKB1R b'));
+        $this->assertTrue($game->playFen('r1bqkbnr/pppp1ppp/2n5/4p3/4P3/5N2/PPPP1PPP/RNBQKB1R w'));
+        $this->assertTrue($game->playFen('r1bqkbnr/pppp1ppp/2n5/4p3/2B1P3/5N2/PPPP1PPP/RNBQK2R b'));
+        $this->assertTrue($game->playFen('r1bqkbnr/pppp1pp1/2n4p/4p3/2B1P3/5N2/PPPP1PPP/RNBQK2R w'));
+        $this->assertTrue($game->playFen('r1bqkbnr/pppp1pp1/2n4p/4p3/2B1P2P/5N2/PPPP1PP1/RNBQK2R b'));
+        $this->assertTrue($game->playFen('r1bqkbnr/pppp1p2/2n4p/4p1p1/2B1P2P/5N2/PPPP1PP1/RNBQK2R w'));
+        $this->assertTrue($game->playFen('r1bqkbnr/pppp1p2/2n4p/4p1P1/2B1P3/5N2/PPPP1PP1/RNBQK2R b'));
+        $this->assertTrue($game->playFen('r1bqkbnr/pppp1p2/2n5/4p1p1/2B1P3/5N2/PPPP1PP1/RNBQK2R w'));
+        $this->assertTrue($game->playFen('r1bqkbnR/pppp1p2/2n5/4p1p1/2B1P3/5N2/PPPP1PP1/RNBQK3 b'));
+        $this->assertTrue($game->playFen('r1bqk1nR/pppp1pb1/2n5/4p1p1/2B1P3/5N2/PPPP1PP1/RNBQK3 w'));
+        $this->assertTrue($game->playFen('r1bqk1nR/pppp1pb1/2n5/4p1p1/2B1P3/3P1N2/PPP2PP1/RNBQK3 b'));
+        $this->assertTrue($game->playFen('r1bqk1nb/pppp1p2/2n5/4p1p1/2B1P3/3P1N2/PPP2PP1/RNBQK3 w'));
+        $this->assertTrue($game->playFen('r1bqk1nb/pppp1p2/2n5/4p1p1/2B1P3/3P1N2/PPP1QPP1/RNB1K3 b'));
+        $this->assertTrue($game->playFen('r1bqk2b/ppppnp2/2n5/4p1p1/2B1P3/3P1N2/PPP1QPP1/RNB1K3 w'));
+        $this->assertTrue($game->playFen('r1bqk2b/ppppnp2/2n5/4p1p1/2B1P3/2PP1N2/PP2QPP1/RNB1K3 b'));
 
         $ascii = $game->ascii();
 
@@ -506,7 +506,7 @@ class PlayTest extends AbstractUnitTestCase
                     " P  P  .  .  Q  P  P  . \n" .
                     " R  N  B  .  K  .  .  . \n";
 
-        $this->assertEquals($expected, $ascii);
+        $this->assertSame($expected, $ascii);
     }
 
     /**
@@ -515,24 +515,24 @@ class PlayTest extends AbstractUnitTestCase
     public function e4_e5_Nf3_Nc6_Bc4_h6_h4_g5_hxg5_hxg5_Rxh8_Bg7_d3_Bxh8_Qe2_Nge7_c3_g4()
     {
         $game = new Game();
-        $this->assertEquals(true, $game->playFen('rnbqkbnr/pppppppp/8/8/4P3/8/PPPP1PPP/RNBQKBNR b'));
-        $this->assertEquals(true, $game->playFen('rnbqkbnr/pppp1ppp/8/4p3/4P3/8/PPPP1PPP/RNBQKBNR w'));
-        $this->assertEquals(true, $game->playFen('rnbqkbnr/pppp1ppp/8/4p3/4P3/5N2/PPPP1PPP/RNBQKB1R b'));
-        $this->assertEquals(true, $game->playFen('r1bqkbnr/pppp1ppp/2n5/4p3/4P3/5N2/PPPP1PPP/RNBQKB1R w'));
-        $this->assertEquals(true, $game->playFen('r1bqkbnr/pppp1ppp/2n5/4p3/2B1P3/5N2/PPPP1PPP/RNBQK2R b'));
-        $this->assertEquals(true, $game->playFen('r1bqkbnr/pppp1pp1/2n4p/4p3/2B1P3/5N2/PPPP1PPP/RNBQK2R w'));
-        $this->assertEquals(true, $game->playFen('r1bqkbnr/pppp1pp1/2n4p/4p3/2B1P2P/5N2/PPPP1PP1/RNBQK2R b'));
-        $this->assertEquals(true, $game->playFen('r1bqkbnr/pppp1p2/2n4p/4p1p1/2B1P2P/5N2/PPPP1PP1/RNBQK2R w'));
-        $this->assertEquals(true, $game->playFen('r1bqkbnr/pppp1p2/2n4p/4p1P1/2B1P3/5N2/PPPP1PP1/RNBQK2R b'));
-        $this->assertEquals(true, $game->playFen('r1bqkbnr/pppp1p2/2n5/4p1p1/2B1P3/5N2/PPPP1PP1/RNBQK2R w'));
-        $this->assertEquals(true, $game->playFen('r1bqkbnR/pppp1p2/2n5/4p1p1/2B1P3/5N2/PPPP1PP1/RNBQK3 b'));
-        $this->assertEquals(true, $game->playFen('r1bqk1nR/pppp1pb1/2n5/4p1p1/2B1P3/5N2/PPPP1PP1/RNBQK3 w'));
-        $this->assertEquals(true, $game->playFen('r1bqk1nR/pppp1pb1/2n5/4p1p1/2B1P3/3P1N2/PPP2PP1/RNBQK3 b'));
-        $this->assertEquals(true, $game->playFen('r1bqk1nb/pppp1p2/2n5/4p1p1/2B1P3/3P1N2/PPP2PP1/RNBQK3 w'));
-        $this->assertEquals(true, $game->playFen('r1bqk1nb/pppp1p2/2n5/4p1p1/2B1P3/3P1N2/PPP1QPP1/RNB1K3 b'));
-        $this->assertEquals(true, $game->playFen('r1bqk2b/ppppnp2/2n5/4p1p1/2B1P3/3P1N2/PPP1QPP1/RNB1K3 w'));
-        $this->assertEquals(true, $game->playFen('r1bqk2b/ppppnp2/2n5/4p1p1/2B1P3/2PP1N2/PP2QPP1/RNB1K3 b'));
-        $this->assertEquals(true, $game->playFen('r1bqk2b/ppppnp2/2n5/4p3/2B1P1p1/2PP1N2/PP2QPP1/RNB1K3 w'));
+        $this->assertTrue($game->playFen('rnbqkbnr/pppppppp/8/8/4P3/8/PPPP1PPP/RNBQKBNR b'));
+        $this->assertTrue($game->playFen('rnbqkbnr/pppp1ppp/8/4p3/4P3/8/PPPP1PPP/RNBQKBNR w'));
+        $this->assertTrue($game->playFen('rnbqkbnr/pppp1ppp/8/4p3/4P3/5N2/PPPP1PPP/RNBQKB1R b'));
+        $this->assertTrue($game->playFen('r1bqkbnr/pppp1ppp/2n5/4p3/4P3/5N2/PPPP1PPP/RNBQKB1R w'));
+        $this->assertTrue($game->playFen('r1bqkbnr/pppp1ppp/2n5/4p3/2B1P3/5N2/PPPP1PPP/RNBQK2R b'));
+        $this->assertTrue($game->playFen('r1bqkbnr/pppp1pp1/2n4p/4p3/2B1P3/5N2/PPPP1PPP/RNBQK2R w'));
+        $this->assertTrue($game->playFen('r1bqkbnr/pppp1pp1/2n4p/4p3/2B1P2P/5N2/PPPP1PP1/RNBQK2R b'));
+        $this->assertTrue($game->playFen('r1bqkbnr/pppp1p2/2n4p/4p1p1/2B1P2P/5N2/PPPP1PP1/RNBQK2R w'));
+        $this->assertTrue($game->playFen('r1bqkbnr/pppp1p2/2n4p/4p1P1/2B1P3/5N2/PPPP1PP1/RNBQK2R b'));
+        $this->assertTrue($game->playFen('r1bqkbnr/pppp1p2/2n5/4p1p1/2B1P3/5N2/PPPP1PP1/RNBQK2R w'));
+        $this->assertTrue($game->playFen('r1bqkbnR/pppp1p2/2n5/4p1p1/2B1P3/5N2/PPPP1PP1/RNBQK3 b'));
+        $this->assertTrue($game->playFen('r1bqk1nR/pppp1pb1/2n5/4p1p1/2B1P3/5N2/PPPP1PP1/RNBQK3 w'));
+        $this->assertTrue($game->playFen('r1bqk1nR/pppp1pb1/2n5/4p1p1/2B1P3/3P1N2/PPP2PP1/RNBQK3 b'));
+        $this->assertTrue($game->playFen('r1bqk1nb/pppp1p2/2n5/4p1p1/2B1P3/3P1N2/PPP2PP1/RNBQK3 w'));
+        $this->assertTrue($game->playFen('r1bqk1nb/pppp1p2/2n5/4p1p1/2B1P3/3P1N2/PPP1QPP1/RNB1K3 b'));
+        $this->assertTrue($game->playFen('r1bqk2b/ppppnp2/2n5/4p1p1/2B1P3/3P1N2/PPP1QPP1/RNB1K3 w'));
+        $this->assertTrue($game->playFen('r1bqk2b/ppppnp2/2n5/4p1p1/2B1P3/2PP1N2/PP2QPP1/RNB1K3 b'));
+        $this->assertTrue($game->playFen('r1bqk2b/ppppnp2/2n5/4p3/2B1P1p1/2PP1N2/PP2QPP1/RNB1K3 w'));
 
         $ascii = $game->ascii();
 
@@ -545,6 +545,6 @@ class PlayTest extends AbstractUnitTestCase
                     " P  P  .  .  Q  P  P  . \n" .
                     " R  N  B  .  K  .  .  . \n";
 
-        $this->assertEquals($expected, $ascii);
+        $this->assertSame($expected, $ascii);
     }
 }

--- a/tests/unit/HeuristicPictureByFenStringTest.php
+++ b/tests/unit/HeuristicPictureByFenStringTest.php
@@ -53,7 +53,7 @@ class HeuristicPictureByFenStringTest extends AbstractUnitTestCase
             Symbol::BLACK => 43.21,
         ];
 
-        $this->assertEquals($expected, $evaluation);
+        $this->assertSame($expected, $evaluation);
     }
 
     /**
@@ -101,7 +101,7 @@ class HeuristicPictureByFenStringTest extends AbstractUnitTestCase
             Symbol::BLACK => 45.51,
         ];
 
-        $this->assertEquals($expected, $evaluation);
+        $this->assertSame($expected, $evaluation);
     }
 
     /**
@@ -149,6 +149,6 @@ class HeuristicPictureByFenStringTest extends AbstractUnitTestCase
             Symbol::BLACK => 46.01,
         ];
 
-        $this->assertEquals($expected, $evaluation);
+        $this->assertSame($expected, $evaluation);
     }
 }

--- a/tests/unit/HeuristicPictureTest.php
+++ b/tests/unit/HeuristicPictureTest.php
@@ -24,7 +24,7 @@ class HeuristicPictureTest extends AbstractUnitTestCase
 
         $expected = 100;
 
-        $this->assertEquals($expected, array_sum($weights));
+        $this->assertSame($expected, array_sum($weights));
     }
 
     /**
@@ -66,7 +66,7 @@ class HeuristicPictureTest extends AbstractUnitTestCase
             Symbol::BLACK => [ 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0 ],
         ];
 
-        $this->assertEquals($expected, $end);
+        $this->assertSame($expected, $end);
     }
 
     /**
@@ -84,7 +84,7 @@ class HeuristicPictureTest extends AbstractUnitTestCase
             [ 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0 ],
         ];
 
-        $this->assertEquals($expected, $balance);
+        $this->assertSame($expected, $balance);
     }
 
     /**
@@ -107,7 +107,7 @@ class HeuristicPictureTest extends AbstractUnitTestCase
             ],
         ];
 
-        $this->assertEquals($expected, $pic);
+        $this->assertSame($expected, $pic);
     }
 
     /**
@@ -126,7 +126,7 @@ class HeuristicPictureTest extends AbstractUnitTestCase
             Symbol::BLACK => [ 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0 ],
         ];
 
-        $this->assertEquals($expected, $end);
+        $this->assertSame($expected, $end);
     }
 
     /**
@@ -144,7 +144,7 @@ class HeuristicPictureTest extends AbstractUnitTestCase
             [ 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0 ],
         ];
 
-        $this->assertEquals($expected, $balance);
+        $this->assertSame($expected, $balance);
     }
 
     /**
@@ -241,7 +241,7 @@ class HeuristicPictureTest extends AbstractUnitTestCase
             Symbol::BLACK => 17.04,
         ];
 
-        $this->assertEquals($expected, $evaluation);
+        $this->assertSame($expected, $evaluation);
     }
 
     /**

--- a/tests/unit/Image/BoardToPngTest.php
+++ b/tests/unit/Image/BoardToPngTest.php
@@ -31,7 +31,7 @@ class BoardToPngTest extends AbstractUnitTestCase
 
         (new BoardToPng($board))->output(self::OUTPUT_FOLDER . '/tmp.png');
 
-        $this->assertEquals(
+        $this->assertSame(
             md5(file_get_contents(self::OUTPUT_FOLDER . '/tmp.png')),
             md5(file_get_contents(self::DATA_FOLDER . '/img/00_starting.png'))
         );
@@ -47,7 +47,7 @@ class BoardToPngTest extends AbstractUnitTestCase
 
         (new BoardToPng($board))->output(self::OUTPUT_FOLDER . '/tmp.png');
 
-        $this->assertEquals(
+        $this->assertSame(
             md5(file_get_contents(self::OUTPUT_FOLDER . '/tmp.png')),
             md5(file_get_contents(self::DATA_FOLDER . '/img/01_kaufman.png'))
         );
@@ -63,7 +63,7 @@ class BoardToPngTest extends AbstractUnitTestCase
 
         (new BoardToPng($board, $flip = true))->output(self::OUTPUT_FOLDER . '/tmp.png');
 
-        $this->assertEquals(
+        $this->assertSame(
             md5(file_get_contents(self::OUTPUT_FOLDER . '/tmp.png')),
             md5(file_get_contents(self::DATA_FOLDER . '/img/01_kaufman_flip.png'))
         );
@@ -79,7 +79,7 @@ class BoardToPngTest extends AbstractUnitTestCase
 
         (new BoardToPng($board))->output(self::OUTPUT_FOLDER . '/tmp.png');
 
-        $this->assertEquals(
+        $this->assertSame(
             md5(file_get_contents(self::OUTPUT_FOLDER . '/tmp.png')),
             md5(file_get_contents(self::DATA_FOLDER . '/img/02_kaufman.png'))
         );
@@ -94,7 +94,7 @@ class BoardToPngTest extends AbstractUnitTestCase
 
         (new BoardToPng($board))->output(self::OUTPUT_FOLDER . '/tmp.png');
 
-        $this->assertEquals(
+        $this->assertSame(
             md5(file_get_contents(self::OUTPUT_FOLDER . '/tmp.png')),
             md5(file_get_contents(self::DATA_FOLDER . '/img/benoni_fianchetto_variation.png'))
         );
@@ -109,7 +109,7 @@ class BoardToPngTest extends AbstractUnitTestCase
 
         (new BoardToPng($board, $flip = true))->output(self::OUTPUT_FOLDER . '/tmp.png');
 
-        $this->assertEquals(
+        $this->assertSame(
             md5(file_get_contents(self::OUTPUT_FOLDER . '/tmp.png')),
             md5(file_get_contents(self::DATA_FOLDER . '/img/benoni_fianchetto_variation_flip.png'))
         );
@@ -124,7 +124,7 @@ class BoardToPngTest extends AbstractUnitTestCase
 
         (new BoardToPng($board))->output(self::OUTPUT_FOLDER . '/tmp.png');
 
-        $this->assertEquals(
+        $this->assertSame(
             md5(file_get_contents(self::OUTPUT_FOLDER . '/tmp.png')),
             md5(file_get_contents(self::DATA_FOLDER . '/img/open_sicilian.png'))
         );
@@ -139,7 +139,7 @@ class BoardToPngTest extends AbstractUnitTestCase
 
         (new BoardToPng($board, $flip = true))->output(self::OUTPUT_FOLDER . '/tmp.png');
 
-        $this->assertEquals(
+        $this->assertSame(
             md5(file_get_contents(self::OUTPUT_FOLDER . '/tmp.png')),
             md5(file_get_contents(self::DATA_FOLDER . '/img/open_sicilian_flip.png'))
         );
@@ -154,7 +154,7 @@ class BoardToPngTest extends AbstractUnitTestCase
 
         (new BoardToPng($board))->output(self::OUTPUT_FOLDER . '/tmp.png');
 
-        $this->assertEquals(
+        $this->assertSame(
             md5(file_get_contents(self::OUTPUT_FOLDER . '/tmp.png')),
             md5(file_get_contents(self::DATA_FOLDER . '/img/closed_sicilian.png'))
         );
@@ -169,7 +169,7 @@ class BoardToPngTest extends AbstractUnitTestCase
 
         (new BoardToPng($board, $flip = true))->output(self::OUTPUT_FOLDER . '/tmp.png');
 
-        $this->assertEquals(
+        $this->assertSame(
             md5(file_get_contents(self::OUTPUT_FOLDER . '/tmp.png')),
             md5(file_get_contents(self::DATA_FOLDER . '/img/closed_sicilian_flip.png'))
         );
@@ -184,7 +184,7 @@ class BoardToPngTest extends AbstractUnitTestCase
 
         (new BoardToPng($board))->output(self::OUTPUT_FOLDER . '/tmp.png');
 
-        $this->assertEquals(
+        $this->assertSame(
             md5(file_get_contents(self::OUTPUT_FOLDER . '/tmp.png')),
             md5(file_get_contents(self::DATA_FOLDER . '/img/lucena_defense.png'))
         );
@@ -199,7 +199,7 @@ class BoardToPngTest extends AbstractUnitTestCase
 
         (new BoardToPng($board))->output(self::OUTPUT_FOLDER . '/tmp.png');
 
-        $this->assertEquals(
+        $this->assertSame(
             md5(file_get_contents(self::OUTPUT_FOLDER . '/tmp.png')),
             md5(file_get_contents(self::DATA_FOLDER . '/img/symmetrical_defense_to_the_queens_gambit.png'))
         );
@@ -214,7 +214,7 @@ class BoardToPngTest extends AbstractUnitTestCase
 
         (new BoardToPng($board, $flip = true))->output(self::OUTPUT_FOLDER . '/tmp.png');
 
-        $this->assertEquals(
+        $this->assertSame(
             md5(file_get_contents(self::OUTPUT_FOLDER . '/tmp.png')),
             md5(file_get_contents(self::DATA_FOLDER . '/img/symmetrical_defense_to_the_queens_gambit_flip.png'))
         );
@@ -229,7 +229,7 @@ class BoardToPngTest extends AbstractUnitTestCase
 
         (new BoardToPng($board))->output(self::OUTPUT_FOLDER . '/tmp.png');
 
-        $this->assertEquals(
+        $this->assertSame(
             md5(file_get_contents(self::DATA_FOLDER . '/img/benko_gambit.png')),
             md5(file_get_contents(self::OUTPUT_FOLDER . '/tmp.png'))
         );
@@ -244,7 +244,7 @@ class BoardToPngTest extends AbstractUnitTestCase
 
         (new BoardToPng($board, $flip = true))->output(self::OUTPUT_FOLDER . '/tmp.png');
 
-        $this->assertEquals(
+        $this->assertSame(
             md5(file_get_contents(self::DATA_FOLDER . '/img/benko_gambit_flip.png')),
             md5(file_get_contents(self::OUTPUT_FOLDER . '/tmp.png'))
         );

--- a/tests/unit/ML/Supervised/Classification/LinearCombinationLabellerTest.php
+++ b/tests/unit/ML/Supervised/Classification/LinearCombinationLabellerTest.php
@@ -50,7 +50,7 @@ class LinearCombinationLabellerTest extends AbstractUnitTestCase
             Symbol::BLACK => 0,
         ];
 
-        $this->assertEquals($expected, $label);
+        $this->assertSame($expected, $label);
     }
 
     /**
@@ -75,7 +75,7 @@ class LinearCombinationLabellerTest extends AbstractUnitTestCase
             Symbol::BLACK => 0,
         ];
 
-        $this->assertEquals($expected, $label);
+        $this->assertSame($expected, $label);
     }
 
     /**
@@ -100,7 +100,7 @@ class LinearCombinationLabellerTest extends AbstractUnitTestCase
 
         $label = (new LinearCombinationLabeller(self::$permutations))->label($end);
 
-        $this->assertEquals($expected, $label);
+        $this->assertSame($expected, $label);
     }
 
     /**
@@ -125,7 +125,7 @@ class LinearCombinationLabellerTest extends AbstractUnitTestCase
 
         $label = (new LinearCombinationLabeller(self::$permutations))->label($end);
 
-        $this->assertEquals($expected, $label);
+        $this->assertSame($expected, $label);
     }
 
     /**
@@ -148,7 +148,7 @@ class LinearCombinationLabellerTest extends AbstractUnitTestCase
 
         $label = (new LinearCombinationLabeller(self::$permutations))->label($end);
 
-        $this->assertEquals($expected, $label);
+        $this->assertSame($expected, $label);
     }
 
     /**
@@ -171,7 +171,7 @@ class LinearCombinationLabellerTest extends AbstractUnitTestCase
 
         $label = (new LinearCombinationLabeller(self::$permutations))->label($end);
 
-        $this->assertEquals($expected, $label);
+        $this->assertSame($expected, $label);
     }
 
     /**
@@ -194,7 +194,7 @@ class LinearCombinationLabellerTest extends AbstractUnitTestCase
 
         $label = (new LinearCombinationLabeller(self::$permutations))->label($end);
 
-        $this->assertEquals($expected, $label);
+        $this->assertSame($expected, $label);
     }
 
     /**
@@ -217,6 +217,6 @@ class LinearCombinationLabellerTest extends AbstractUnitTestCase
 
         $label = (new LinearCombinationLabeller(self::$permutations))->label($end);
 
-        $this->assertEquals($expected, $label);
+        $this->assertSame($expected, $label);
     }
 }

--- a/tests/unit/PGN/MovetextTest.php
+++ b/tests/unit/PGN/MovetextTest.php
@@ -29,7 +29,7 @@ class MovetextTest extends AbstractUnitTestCase
      */
     public function sequence($text, $expected)
     {
-        $this->assertEquals($expected, (new Movetext($text))->sequence());
+        $this->assertSame($expected, (new Movetext($text))->sequence());
     }
 
     public function orderData()

--- a/tests/unit/PGN/Validate/ColorTest.php
+++ b/tests/unit/PGN/Validate/ColorTest.php
@@ -23,7 +23,7 @@ class ColorTest extends AbstractUnitTestCase
      */
     public function white()
     {
-        $this->assertEquals(Symbol::WHITE, Validate::color(Symbol::WHITE));
+        $this->assertSame(Symbol::WHITE, Validate::color(Symbol::WHITE));
     }
 
     /**
@@ -31,6 +31,6 @@ class ColorTest extends AbstractUnitTestCase
      */
     public function black()
     {
-        $this->assertEquals(Symbol::BLACK, Validate::color(Symbol::BLACK));
+        $this->assertSame(Symbol::BLACK, Validate::color(Symbol::BLACK));
     }
 }

--- a/tests/unit/PGN/Validate/MovetextTest.php
+++ b/tests/unit/PGN/Validate/MovetextTest.php
@@ -22,7 +22,7 @@ class MovetextTest extends AbstractUnitTestCase
      */
     public function valid($movetext)
     {
-        $this->assertEquals($movetext, Validate::movetext($movetext));
+        $this->assertSame($movetext, Validate::movetext($movetext));
     }
 
     /**
@@ -31,7 +31,7 @@ class MovetextTest extends AbstractUnitTestCase
      */
     public function comments_removed($expected, $movetext)
     {
-        $this->assertEquals($expected, Validate::movetext($movetext));
+        $this->assertSame($expected, Validate::movetext($movetext));
     }
 
     /**
@@ -40,7 +40,7 @@ class MovetextTest extends AbstractUnitTestCase
      */
     public function too_many_spaces($expected, $movetext)
     {
-        $this->assertEquals($expected, Validate::movetext($movetext));
+        $this->assertSame($expected, Validate::movetext($movetext));
     }
 
     /**

--- a/tests/unit/PGN/Validate/SquareTest.php
+++ b/tests/unit/PGN/Validate/SquareTest.php
@@ -53,6 +53,6 @@ class SquareTest extends AbstractUnitTestCase
      */
     public function e4()
     {
-        $this->assertEquals(Validate::square('e4'), 'e4');
+        $this->assertSame(Validate::square('e4'), 'e4');
     }
 }

--- a/tests/unit/PGN/Validate/TagTest.php
+++ b/tests/unit/PGN/Validate/TagTest.php
@@ -26,8 +26,8 @@ class TagTest extends AbstractUnitTestCase
     {
         $tag = Validate::tag('[Event "Vladimir Dvorkovich Cup"]');
 
-        $this->assertEquals('Event', $tag->name);
-        $this->assertEquals('Vladimir Dvorkovich Cup', $tag->value);
+        $this->assertSame('Event', $tag->name);
+        $this->assertSame('Vladimir Dvorkovich Cup', $tag->value);
     }
 
     /**
@@ -37,8 +37,8 @@ class TagTest extends AbstractUnitTestCase
     {
         $tag = Validate::tag('[Site "Saint Louis USA"]');
 
-        $this->assertEquals('Site', $tag->name);
-        $this->assertEquals('Saint Louis USA', $tag->value);
+        $this->assertSame('Site', $tag->name);
+        $this->assertSame('Saint Louis USA', $tag->value);
     }
 
     /**
@@ -48,8 +48,8 @@ class TagTest extends AbstractUnitTestCase
     {
         $tag = Validate::tag('[Date "2018.05.10"]');
 
-        $this->assertEquals('Date', $tag->name);
-        $this->assertEquals('2018.05.10', $tag->value);
+        $this->assertSame('Date', $tag->name);
+        $this->assertSame('2018.05.10', $tag->value);
     }
 
     /**
@@ -59,8 +59,8 @@ class TagTest extends AbstractUnitTestCase
     {
         $tag = Validate::tag('[Round "9.6"]');
 
-        $this->assertEquals('Round', $tag->name);
-        $this->assertEquals('9.6', $tag->value);
+        $this->assertSame('Round', $tag->name);
+        $this->assertSame('9.6', $tag->value);
     }
 
     /**
@@ -70,8 +70,8 @@ class TagTest extends AbstractUnitTestCase
     {
         $tag = Validate::tag('[White "Kantor, Gergely"]');
 
-        $this->assertEquals('White', $tag->name);
-        $this->assertEquals('Kantor, Gergely', $tag->value);
+        $this->assertSame('White', $tag->name);
+        $this->assertSame('Kantor, Gergely', $tag->value);
     }
 
     /**
@@ -81,8 +81,8 @@ class TagTest extends AbstractUnitTestCase
     {
         $tag = Validate::tag('[Black "Gelfand, Boris"]');
 
-        $this->assertEquals('Black', $tag->name);
-        $this->assertEquals('Gelfand, Boris', $tag->value);
+        $this->assertSame('Black', $tag->name);
+        $this->assertSame('Gelfand, Boris', $tag->value);
     }
 
     /**
@@ -92,8 +92,8 @@ class TagTest extends AbstractUnitTestCase
     {
         $tag = Validate::tag('[Result "1/2-1/2"]');
 
-        $this->assertEquals('Result', $tag->name);
-        $this->assertEquals('1/2-1/2', $tag->value);
+        $this->assertSame('Result', $tag->name);
+        $this->assertSame('1/2-1/2', $tag->value);
     }
 
     /**
@@ -103,8 +103,8 @@ class TagTest extends AbstractUnitTestCase
     {
         $tag = Validate::tag('[WhiteElo "2579"]');
 
-        $this->assertEquals('WhiteElo', $tag->name);
-        $this->assertEquals('2579', $tag->value);
+        $this->assertSame('WhiteElo', $tag->name);
+        $this->assertSame('2579', $tag->value);
     }
 
     /**
@@ -114,8 +114,8 @@ class TagTest extends AbstractUnitTestCase
     {
         $tag = Validate::tag('[BlackElo "2474"]');
 
-        $this->assertEquals('BlackElo', $tag->name);
-        $this->assertEquals('2474', $tag->value);
+        $this->assertSame('BlackElo', $tag->name);
+        $this->assertSame('2474', $tag->value);
     }
 
     /**
@@ -125,8 +125,8 @@ class TagTest extends AbstractUnitTestCase
     {
         $tag = Validate::tag('[ECO "D35"]');
 
-        $this->assertEquals('ECO', $tag->name);
-        $this->assertEquals('D35', $tag->value);
+        $this->assertSame('ECO', $tag->name);
+        $this->assertSame('D35', $tag->value);
     }
 
     /**
@@ -136,7 +136,7 @@ class TagTest extends AbstractUnitTestCase
     {
         $tag = Validate::tag('[EventDate "2017.12.17"]');
 
-        $this->assertEquals('EventDate', $tag->name);
-        $this->assertEquals('2017.12.17', $tag->value);
+        $this->assertSame('EventDate', $tag->name);
+        $this->assertSame('2017.12.17', $tag->value);
     }
 }

--- a/tests/unit/Piece/KnightTest.php
+++ b/tests/unit/Piece/KnightTest.php
@@ -25,7 +25,7 @@ class KnightTest extends AbstractUnitTestCase
             'e6'
         ];
 
-        $this->assertEquals($jumps, $knight->getScope()->jumps);
+        $this->assertSame($jumps, $knight->getScope()->jumps);
     }
 
     /**
@@ -39,7 +39,7 @@ class KnightTest extends AbstractUnitTestCase
             'f2'
         ];
 
-        $this->assertEquals($jumps, $knight->getScope()->jumps);
+        $this->assertSame($jumps, $knight->getScope()->jumps);
     }
 
     /**
@@ -54,6 +54,6 @@ class KnightTest extends AbstractUnitTestCase
             'c3'
         ];
 
-        $this->assertEquals($jumps, $knight->getScope()->jumps);
+        $this->assertSame($jumps, $knight->getScope()->jumps);
     }
 }

--- a/tests/unit/Piece/PawnTest.php
+++ b/tests/unit/Piece/PawnTest.php
@@ -19,9 +19,9 @@ class PawnTest extends AbstractUnitTestCase
         $scope = (object) ['up' => ['a3', 'a4']];
         $captureSquares = ['b3'];
 
-        $this->assertEquals($position, $pawn->getPosition());
+        $this->assertSame($position, $pawn->getPosition());
         $this->assertEquals($scope, $pawn->getScope());
-        $this->assertEquals($captureSquares, $pawn->getCaptureSquares());
+        $this->assertSame($captureSquares, $pawn->getCaptureSquares());
     }
 
     /**
@@ -35,9 +35,9 @@ class PawnTest extends AbstractUnitTestCase
         $scope = (object) ['up' => ['d6']];
         $captureSquares = ['c6', 'e6'];
 
-        $this->assertEquals($position, $pawn->getPosition());
+        $this->assertSame($position, $pawn->getPosition());
         $this->assertEquals($scope, $pawn->getScope());
-        $this->assertEquals($captureSquares, $pawn->getCaptureSquares());
+        $this->assertSame($captureSquares, $pawn->getCaptureSquares());
     }
 
     /**
@@ -51,9 +51,9 @@ class PawnTest extends AbstractUnitTestCase
         $scope = (object) ['up' => ['f8']];
         $captureSquares = ['e8', 'g8'];
 
-        $this->assertEquals($position, $pawn->getPosition());
+        $this->assertSame($position, $pawn->getPosition());
         $this->assertEquals($scope, $pawn->getScope());
-        $this->assertEquals($captureSquares, $pawn->getCaptureSquares());
+        $this->assertSame($captureSquares, $pawn->getCaptureSquares());
     }
 
     /**
@@ -67,9 +67,9 @@ class PawnTest extends AbstractUnitTestCase
         $scope = (object) ['up' => []];
         $captureSquares = [];
 
-        $this->assertEquals($position, $pawn->getPosition());
+        $this->assertSame($position, $pawn->getPosition());
         $this->assertEquals($scope, $pawn->getScope());
-        $this->assertEquals($captureSquares, $pawn->getCaptureSquares());
+        $this->assertSame($captureSquares, $pawn->getCaptureSquares());
     }
 
     /**
@@ -83,9 +83,9 @@ class PawnTest extends AbstractUnitTestCase
         $scope = (object) ['up' => ['a1']];
         $captureSquares = ['b1'];
 
-        $this->assertEquals($position, $pawn->getPosition());
+        $this->assertSame($position, $pawn->getPosition());
         $this->assertEquals($scope, $pawn->getScope());
-        $this->assertEquals($captureSquares, $pawn->getCaptureSquares());
+        $this->assertSame($captureSquares, $pawn->getCaptureSquares());
     }
 
     /**
@@ -99,8 +99,8 @@ class PawnTest extends AbstractUnitTestCase
         $scope = (object) ['up' => ['d4']];
         $captureSquares = ['c4', 'e4'];
 
-        $this->assertEquals($position, $pawn->getPosition());
+        $this->assertSame($position, $pawn->getPosition());
         $this->assertEquals($scope, $pawn->getScope());
-        $this->assertEquals($captureSquares, $pawn->getCaptureSquares());
+        $this->assertSame($captureSquares, $pawn->getCaptureSquares());
     }
 }


### PR DESCRIPTION
# Changed log

- Using the `assertSame` to let equals assertions be strict.
- Using the `assertTrue` to assert expected is `true`.
- Using the `assertFalse` to assert expected is `false`.
- Using the `assertNull` to assert expected is `null`.