### PR TITLE
Fix isolated pawn evaluation feature

### DIFF
--- a/src/Evaluation/AbstractEvaluation.php
+++ b/src/Evaluation/AbstractEvaluation.php
@@ -13,24 +13,18 @@ use Chess\PGN\Symbol;
  */
 abstract class AbstractEvaluation
 {
+    protected $isInversed;
+
     protected $board;
 
     protected $value;
 
     protected $result;
 
-    /**
-     * It's true if the metric is inversely correlated to the balance.
-     * Example - directly correlated: the material is directly correlated to the advantage, if white has more
-     * material than black than the balance tends towards white.
-     * Example - inversely correlated: isolated pawns are inversely correlated to the advantage, if white has more
-     * isolated pawns than black than the balance tends towards black.
-     * @var
-     */
-    public static $isInverselyCorrelated = false;
-
     public function __construct(Board $board)
     {
+        $this->isInversed = false;
+
         $this->board = $board;
 
         $this->value = [
@@ -40,5 +34,10 @@ abstract class AbstractEvaluation
             Symbol::ROOK => 5.1,
             Symbol::QUEEN => 8.8,
         ];
+    }
+
+    public function isInversed()
+    {
+        return $this->isInversed;
     }
 }

--- a/src/Evaluation/AbstractEvaluation.php
+++ b/src/Evaluation/AbstractEvaluation.php
@@ -13,18 +13,16 @@ use Chess\PGN\Symbol;
  */
 abstract class AbstractEvaluation
 {
-    protected $isInversed;
-
     protected $board;
 
     protected $value;
 
     protected $result;
 
+    protected $isInverse;
+
     public function __construct(Board $board)
     {
-        $this->isInversed = false;
-
         $this->board = $board;
 
         $this->value = [
@@ -34,10 +32,12 @@ abstract class AbstractEvaluation
             Symbol::ROOK => 5.1,
             Symbol::QUEEN => 8.8,
         ];
+
+        $this->isInverse = false;
     }
 
-    public function isInversed()
+    public function isInverse()
     {
-        return $this->isInversed;
+        return $this->isInverse;
     }
 }

--- a/src/Evaluation/AbstractEvaluation.php
+++ b/src/Evaluation/AbstractEvaluation.php
@@ -24,7 +24,7 @@ abstract class AbstractEvaluation
      * Example - directly correlated: the material is directly correlated to the advantage, if white has more
      * material than black than the balance tends towards white.
      * Example - inversely correlated: isolated pawns are inversely correlated to the advantage, if white has more
-     * material than black than the balance tends towards black.
+     * isolated pawns than black than the balance tends towards black.
      * @var
      */
     public static $isInverselyCorrelated = false;

--- a/src/Evaluation/AbstractEvaluation.php
+++ b/src/Evaluation/AbstractEvaluation.php
@@ -19,6 +19,16 @@ abstract class AbstractEvaluation
 
     protected $result;
 
+    /**
+     * It's true if the metric is inversely correlated to the balance.
+     * Example - directly correlated: the material is directly correlated to the advantage, if white has more
+     * material than black than the balance tends towards white.
+     * Example - inversely correlated: isolated pawns are inversely correlated to the advantage, if white has more
+     * material than black than the balance tends towards black.
+     * @var
+     */
+    public static $isInverselyCorrelated = false;
+
     public function __construct(Board $board)
     {
         $this->board = $board;

--- a/src/Evaluation/IsolatedPawnEvaluation.php
+++ b/src/Evaluation/IsolatedPawnEvaluation.php
@@ -10,11 +10,11 @@ class IsolatedPawnEvaluation extends AbstractEvaluation
 {
     const NAME = 'isolated_pawn';
 
-    public static $isInverselyCorrelated = true;
-
     public function __construct(Board $board)
     {
         parent::__construct($board);
+
+        $this->isInversed = true;
 
         $this->result = [
             Symbol::WHITE => 0,

--- a/src/Evaluation/IsolatedPawnEvaluation.php
+++ b/src/Evaluation/IsolatedPawnEvaluation.php
@@ -10,6 +10,8 @@ class IsolatedPawnEvaluation extends AbstractEvaluation
 {
     const NAME = 'isolated_pawn';
 
+    public static $isInverselyCorrelated = true;
+
     public function __construct(Board $board)
     {
         parent::__construct($board);

--- a/src/Evaluation/IsolatedPawnEvaluation.php
+++ b/src/Evaluation/IsolatedPawnEvaluation.php
@@ -14,7 +14,7 @@ class IsolatedPawnEvaluation extends AbstractEvaluation
     {
         parent::__construct($board);
 
-        $this->isInversed = true;
+        $this->isInverse = true;
 
         $this->result = [
             Symbol::WHITE => 0,

--- a/src/HeuristicPicture.php
+++ b/src/HeuristicPicture.php
@@ -85,7 +85,7 @@ class HeuristicPicture extends Player
                 $dimension = new $className($this->board);
                 $evald = $dimension->evaluate();
                 if (is_array($evald[Symbol::WHITE])) {
-                    $dimension->isInversed()
+                    $dimension->isInverse()
                         ? $item[] = [
                             Symbol::WHITE => count($evald[Symbol::BLACK]),
                             Symbol::BLACK => count($evald[Symbol::WHITE]),
@@ -95,7 +95,7 @@ class HeuristicPicture extends Player
                             Symbol::BLACK => count($evald[Symbol::BLACK]),
                         ];
                 } else {
-                    $dimension->isInversed()
+                    $dimension->isInverse()
                         ? $item[] = [
                             Symbol::WHITE => $evald[Symbol::BLACK],
                             Symbol::BLACK => $evald[Symbol::WHITE],

--- a/src/HeuristicPicture.php
+++ b/src/HeuristicPicture.php
@@ -81,31 +81,26 @@ class HeuristicPicture extends Player
                 $this->board->play(Symbol::BLACK, $move[1]);
             }
             $item = [];
-            foreach ($this->dimensions as $dimension => $w) {
-                // get instance of dimension
-                $dimension = new $dimension($this->board);
+            foreach ($this->dimensions as $className => $weight) {
+                $dimension = new $className($this->board);
                 $evald = $dimension->evaluate();
-
                 if (is_array($evald[Symbol::WHITE])) {
-                    if ($dimension::$isInverselyCorrelated) {
-                        $item[] = [
+                    $dimension->isInversed()
+                        ? $item[] = [
                             Symbol::WHITE => count($evald[Symbol::BLACK]),
-                            Symbol::BLACK => count($evald[Symbol::WHITE])
-                        ];
-                    } else {
-                        $item[] = [
+                            Symbol::BLACK => count($evald[Symbol::WHITE]),
+                        ]
+                        : $item[] = [
                             Symbol::WHITE => count($evald[Symbol::WHITE]),
-                            Symbol::BLACK => count($evald[Symbol::BLACK])];
-                    }
-                } else {
-                    if ($dimension::$isInverselyCorrelated) {
-                        $item[] = [
-                            Symbol::WHITE => $evald[Symbol::BLACK],
-                            Symbol::BLACK => $evald[Symbol::WHITE]
+                            Symbol::BLACK => count($evald[Symbol::BLACK]),
                         ];
-                    } else {
-                        $item[] = $evald;
-                    }
+                } else {
+                    $dimension->isInversed()
+                        ? $item[] = [
+                            Symbol::WHITE => $evald[Symbol::BLACK],
+                            Symbol::BLACK => $evald[Symbol::WHITE],
+                        ]
+                        : $item[] = $evald;
                 }
             }
             $this->picture[Symbol::WHITE][] = array_column($item, Symbol::WHITE);

--- a/src/HeuristicPicture.php
+++ b/src/HeuristicPicture.php
@@ -82,12 +82,31 @@ class HeuristicPicture extends Player
             }
             $item = [];
             foreach ($this->dimensions as $dimension => $w) {
-                $evald = (new $dimension($this->board))->evaluate();
-                is_array($evald[Symbol::WHITE])
-                    ? $item[] = [
-                        Symbol::WHITE => count($evald[Symbol::WHITE]),
-                        Symbol::BLACK => count($evald[Symbol::BLACK])]
-                    : $item[] = $evald;
+                // get instance of dimension
+                $dimension = new $dimension($this->board);
+                $evald = $dimension->evaluate();
+
+                if (is_array($evald[Symbol::WHITE])) {
+                    if ($dimension::$isInverselyCorrelated) {
+                        $item[] = [
+                            Symbol::WHITE => count($evald[Symbol::BLACK]),
+                            Symbol::BLACK => count($evald[Symbol::WHITE])
+                        ];
+                    } else {
+                        $item[] = [
+                            Symbol::WHITE => count($evald[Symbol::WHITE]),
+                            Symbol::BLACK => count($evald[Symbol::BLACK])];
+                    }
+                } else {
+                    if ($dimension::$isInverselyCorrelated) {
+                        $item[] = [
+                            Symbol::WHITE => $evald[Symbol::BLACK],
+                            Symbol::BLACK => $evald[Symbol::WHITE]
+                        ];
+                    } else {
+                        $item[] = $evald;
+                    }
+                }
             }
             $this->picture[Symbol::WHITE][] = array_column($item, Symbol::WHITE);
             $this->picture[Symbol::BLACK][] = array_column($item, Symbol::BLACK);

--- a/tests/unit/Game/HeuristicPictureTest.php
+++ b/tests/unit/Game/HeuristicPictureTest.php
@@ -2,7 +2,6 @@
 
 namespace Chess\Tests\Unit\Game;
 
-use Chess\Evaluation\IsolatedPawnEvaluation;
 use Chess\Game;
 use Chess\Tests\AbstractUnitTestCase;
 

--- a/tests/unit/Game/HeuristicPictureTest.php
+++ b/tests/unit/Game/HeuristicPictureTest.php
@@ -2,6 +2,7 @@
 
 namespace Chess\Tests\Unit\Game;
 
+use Chess\Evaluation\IsolatedPawnEvaluation;
 use Chess\Game;
 use Chess\Tests\AbstractUnitTestCase;
 
@@ -58,8 +59,11 @@ class HeuristicPictureTest extends AbstractUnitTestCase
         $game->play('w', 'Nf6');
         $game->play('b', 'gxf6');
 
+        // in this configuration black has one isolated pawn in h7, white has no isolated pawns
+        // the heuristic picture has an advantage of white in terms of isolated pawns so second-last value
+        // of expected must be 1 instead of -1
         $expected = [
-            [ -1, -1, -1, 1, 1, 0, 0, 0, 1, -1, -1, 0 ],
+            [ -1, -1, -1, 1, 1, 0, 0, 0, 1, -1, 1, 0 ],
         ];
 
         $balance = $game->heuristicPicture(true);

--- a/tests/unit/HeuristicPictureTest.php
+++ b/tests/unit/HeuristicPictureTest.php
@@ -3,6 +3,7 @@
 namespace Chess\Tests\Unit;
 
 use Chess\Board;
+use Chess\Evaluation\IsolatedPawnEvaluation;
 use Chess\HeuristicPicture;
 use Chess\Tests\AbstractUnitTestCase;
 use Chess\Tests\Sample\Checkmate\Fool as FoolCheckmate;
@@ -408,6 +409,29 @@ class HeuristicPictureTest extends AbstractUnitTestCase
 
         $expected = [
             [ 0, 1, -1, 1, -1, 0, -1, 0, 0, 0, 0, 0 ],
+        ];
+
+        $this->assertEquals($expected, $balance);
+    }
+
+    /**
+     * @test
+     */
+    public function isolated_pawn_take_get_balance()
+    {
+        $movetext = '1.d4 d5 2.e4 e5 3.f4 f5 4.exd5 exd4 5.c3 dxc3 6.Nxc3';
+
+        $heuristicPicture = new HeuristicPicture($movetext);
+        // let's test only this heuristic
+        $heuristicPicture->setDimensions(
+            [IsolatedPawnEvaluation::class => 5]
+        );
+
+        $balance = $heuristicPicture->take()
+            ->getBalance();
+
+        $expected = [
+            [0], [0], [0], [0], [-1], [-1]
         ];
 
         $this->assertEquals($expected, $balance);


### PR DESCRIPTION
Closes #150

`\Evaluation\IsolatedPawnEvaluation` is correctly working: if white has 1 isolated pawn and black has 2 isolated pawns then the output of the evaluation will be 1 for white and 2 for black.
The problem is that if white has **more** isolated pawns than black, than white is in a situation of **disadvantage**. It means that the number of pawns of a player is **inversely correlated** to the advantage of the player. Most of the feature are **directly correlated** to the advantage: material, for example, is directly correlated to the advantage (it's better to have more material than the opponent).

I thought that the category of features inversely correlated to the advantage had to be recognized thanks to a static property of the representing class: when `isInverselyCorrelated` is `true`, we need to exchange the values of the feature between the two players in the moment in which we are calculating the balance. So if it's true that white has 1 isolated pawn while black has 0 isolated pawns, the advantage is actually for black so we want to exchange the values to get -1 instead of 1 for the balance.

This could have been possible by implementing a check in `HeuristicPicture`.

According to this fix #151 should become easy to fix: we'll only need to set `isInverselyCorrelated` to `true` for the feature related to the backward pawn. 

All tests are OK (I had to correct a single test which was giving failure).