### PR TITLE
Using the Ubuntu 18.04 and add -x264-params

### DIFF
--- a/.github/workflows/php.yml
+++ b/.github/workflows/php.yml
@@ -12,7 +12,7 @@ permissions:
 jobs:
   build:
 
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-18.04
     strategy:
       matrix:
         php-versions: [ '8.1' ]

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -13,7 +13,7 @@
             <directory>tests/unit/Combinatorics</directory>
             <directory>tests/unit/Evaluation</directory>
             <directory>tests/unit/FEN</directory>
-            <directory>tests/unit/Media/BoardToPngTest.php</directory>
+            <directory>tests/unit/Media</directory>
             <directory>tests/unit/ML</directory>
             <directory>tests/unit/PGN</directory>
             <directory>tests/unit/Piece</directory>

--- a/src/Media/BoardToMp4.php
+++ b/src/Media/BoardToMp4.php
@@ -47,7 +47,7 @@ class BoardToMp4
 
     private function animate(string $filepath, string $filename): BoardToMp4
     {
-        $cmd = "ffmpeg -r 1 -pattern_type glob -i {$filepath}/{$filename}*.png -vf fps=25 -pix_fmt yuv420p {$filepath}/{$filename}.mp4";
+        $cmd = "ffmpeg -r 1 -pattern_type glob -i {$filepath}/{$filename}*.png -vf fps=25 -x264-params threads=6 -pix_fmt yuv420p {$filepath}/{$filename}.mp4";
         $escapedCmd = escapeshellcmd($cmd);
         exec($escapedCmd);
 


### PR DESCRIPTION
# Changed log

- Resolving the issue that mentioned on this [PR](https://github.com/chesslablab/php-chess/pull/209#issuecomment-1124517574).
- To resolve above issue, it should use the `Ubuntu 18.04` dist to be the test environment on GitHub workflows. And it can be the same FFmpeg version as the local machine. By default, the `ubuntu-latest` is `Ubuntu 20.04` dist.
- After digging the FFmpeg output log, the `H.264/MPEG-4 AVC codec` options are different from the local machine's. The difference is about `threads` option.
  - The default thread option is `3` on GitHub workflows with `Ubuntu 18.04` and the thread option is `6` on my local machine and local @programarivm machine.
  - To resolve above issue, using the `-x264-params` to set the `threads=6` option and it can generate the same MP4 video file.
  - I guess above issue happens because the `X264` codec will detect current running hardware machine and set the different processing threads.
- After modifying all of above changes, the GitHub workflow actions is expected to be successful :).