### PR TITLE
validation: add terminating of extended characters

### DIFF
--- a/src/PGN/AN/Termination.php
+++ b/src/PGN/AN/Termination.php
@@ -16,7 +16,8 @@ class Termination extends AbstractNotation
     const BLACK_WINS = '0-1';
     const DRAW = '1/2-1/2';
     const UNKNOWN = '*';
-    const WHITE_WINS_EXTENDED_ASCII = '1–0';
-    const BLACK_WINDS_EXTENDED_ASCII = '0–1';
-    const DRAW_EXTENDED_ASCII = '½–½';
+    const WHITE_WINS_EXTENDED_ASCII_150 = '1–0';
+    const BLACK_WINDS_EXTENDED_ASCII_150 = '0–1';
+    const DRAW_EXTENDED_ASCII_150 = '1/2–1/2';
+    const DRAW_EXTENDED_ASCII_150_189 = '½–½';
 }

--- a/src/PGN/AN/Termination.php
+++ b/src/PGN/AN/Termination.php
@@ -16,4 +16,7 @@ class Termination extends AbstractNotation
     const BLACK_WINS = '0-1';
     const DRAW = '1/2-1/2';
     const UNKNOWN = '*';
+    const WHITE_WINS_EXTENDED_ASCII = '1–0';
+    const BLACK_WINDS_EXTENDED_ASCII = '0–1';
+    const DRAW_EXTENDED_ASCII = '½–½';
 }

--- a/tests/unit/MovetextTest.php
+++ b/tests/unit/MovetextTest.php
@@ -13,6 +13,7 @@ class MovetextTest extends AbstractUnitTestCase
         '1.e4 c5 2.Nf3 Nc6 3.d4 cxd4 4.Nxd4 Nf6 5.Nc3 e5 6.Ndb5 d6 7.Bg5 a6 8.Na3',
         '1.d4 Nf6 2.c4 e6 3.Nc3 Bb4 4.e3 O-O 5.a3 Bxc3+ 6.bxc3 b6 7.Bd3 Bb7 8.f3 c5',
         '1.Nf3 Nf6 2.c4 c5 3.g3 b6 4.Bg2 Bb7 5.O-O e6 6.Nc3 a6 7.d4 cxd4 8.Qxd4 d6',
+        '1.e4 c6 2.Nc3 d5 3.Nf3 dxe4 4.Nxe4 Nf6 5.Qe2 Nbd7 6.Nd6'
     ];
 
     /**
@@ -210,6 +211,7 @@ class MovetextTest extends AbstractUnitTestCase
             [ self::$validData[2], self::$validData[2] . ' 1/2-1/2' ],
             [ self::$validData[3], self::$validData[3] . ' *' ],
             [ self::$validData[4], self::$validData[4] . ' 1-0' ],
+            [ self::$validData[5], self::$validData[5] . ' 1–0' ],
         ];
     }
 

--- a/tests/unit/MovetextTest.php
+++ b/tests/unit/MovetextTest.php
@@ -13,7 +13,6 @@ class MovetextTest extends AbstractUnitTestCase
         '1.e4 c5 2.Nf3 Nc6 3.d4 cxd4 4.Nxd4 Nf6 5.Nc3 e5 6.Ndb5 d6 7.Bg5 a6 8.Na3',
         '1.d4 Nf6 2.c4 e6 3.Nc3 Bb4 4.e3 O-O 5.a3 Bxc3+ 6.bxc3 b6 7.Bd3 Bb7 8.f3 c5',
         '1.Nf3 Nf6 2.c4 c5 3.g3 b6 4.Bg2 Bb7 5.O-O e6 6.Nc3 a6 7.d4 cxd4 8.Qxd4 d6',
-        '1.e4 c6 2.Nc3 d5 3.Nf3 dxe4 4.Nxe4 Nf6 5.Qe2 Nbd7 6.Nd6'
     ];
 
     /**
@@ -210,8 +209,10 @@ class MovetextTest extends AbstractUnitTestCase
             [ self::$validData[1], self::$validData[1] . ' 0-1' ],
             [ self::$validData[2], self::$validData[2] . ' 1/2-1/2' ],
             [ self::$validData[3], self::$validData[3] . ' *' ],
-            [ self::$validData[4], self::$validData[4] . ' 1-0' ],
-            [ self::$validData[5], self::$validData[5] . ' 1–0' ],
+            [ self::$validData[4], self::$validData[4] . ' 1–0' ],
+            [ self::$validData[0], self::$validData[0] . ' 0–1' ],
+            [ self::$validData[1], self::$validData[1] . ' 1/2–1/2' ],
+            [ self::$validData[2], self::$validData[2] . ' ½–½' ],
         ];
     }
 


### PR DESCRIPTION
These characters are removing by ```\Chess\Movetext::filter``` function. I decided to extend it by characters which are using on websites based on extended ASCII.
