### PR TITLE
Remove extra parameters from class methods

### DIFF
--- a/tests/unit/Eval/SqEvalTest.php
+++ b/tests/unit/Eval/SqEvalTest.php
@@ -15,7 +15,7 @@ class SqEvalTest extends AbstractUnitTestCase
     {
         $board = new Board();
 
-        $sqEval = (new SqEval($board))->eval(SqEval::TYPE_FREE);
+        $sqEval = (new SqEval($board))->eval();
 
         $expected = [
             'a3', 'a4', 'a5', 'a6',

--- a/tests/unit/Variant/Classical/BoardTest.php
+++ b/tests/unit/Variant/Classical/BoardTest.php
@@ -2321,7 +2321,7 @@ class BoardTest extends AbstractUnitTestCase
         $board->play('w', 'e4');
         $board->play('b', 'e5');
 
-        $board = $board->undo($board->getCastlingAbility());
+        $board = $board->undo();
 
         $expected = 'rnbqkbnr/pppppppp/8/8/4P3/8/PPPP1PPP/RNBQKBNR b KQkq e3';
 


### PR DESCRIPTION
# Changed log

- Removing extra parameters from `eval` and `undo` methods because they're not necessary.